### PR TITLE
feat(opapi): add isApiError field to errors

### DIFF
--- a/opapi/src/generators/errors.ts
+++ b/opapi/src/generators/errors.ts
@@ -20,6 +20,8 @@ const codes = {
 type ErrorCode = typeof codes[keyof typeof codes]
 
 abstract class BaseApiError<Code extends ErrorCode, Type extends string, Description extends string> extends Error {
+  public readonly isApiError = true
+
   constructor(
     public readonly code: Code,
     public readonly description: Description,
@@ -39,8 +41,12 @@ abstract class BaseApiError<Code extends ErrorCode, Type extends string, Descrip
   }
 }
 
+function isObject(obj: unknown): obj is object {
+  return typeof obj === 'object' && !Array.isArray(obj) && obj !== null
+}
+
 export const isApiError = (thrown: unknown): thrown is ApiError => {
-  return thrown instanceof BaseApiError 
+  return thrown instanceof BaseApiError || isObject(thrown) && thrown.isApiError === true
 }
 
 ${errors.map((err) => generateError(err)).join('\n')}
@@ -48,7 +54,7 @@ ${generateErrorType(types)}
 ${generateApiError(types)}
 ${generateErrorTypeMap(types)}
 export const errorFrom = (err: unknown): ApiError => {
-  if (err instanceof BaseApiError) {
+  if (isApiError(err)) {
     return err
   }
 

--- a/opapi/src/generators/errors.ts
+++ b/opapi/src/generators/errors.ts
@@ -41,9 +41,7 @@ abstract class BaseApiError<Code extends ErrorCode, Type extends string, Descrip
   }
 }
 
-function isObject(obj: unknown): obj is object {
-  return typeof obj === 'object' && !Array.isArray(obj) && obj !== null
-}
+const isObject = (obj: unknown): obj is object => typeof obj === 'object' && !Array.isArray(obj) && obj !== null
 
 export const isApiError = (thrown: unknown): thrown is ApiError => {
   return thrown instanceof BaseApiError || isObject(thrown) && thrown.isApiError === true


### PR DESCRIPTION
Closes CLS-697

Adding the `isApiError=true` field ensures the `isApiError()` check can succeed for `BaseApiError` instances that were created outside of the current generated code.

For example, we have a `Server` class that uses receives an error from a 3rd party library called `Client`. The `Server` receives an error `e`, which he wants to pass to `isApiError(e)`. Since the `Server` uses his own opapi-generated `isApiError()` function, the `isApiError(e)` will always fail since the `BaseApiError` used by `Server` is not necessarily the same `BaseApiError` class used by the 3rd party `Client`.

Adding the `isApiError=true` field solves this problem.