### PR TITLE
feat(tunnel): added pingpong feature to keep connection alive

### DIFF
--- a/tunnel/e2e/browser/index.ts
+++ b/tunnel/e2e/browser/index.ts
@@ -21,13 +21,13 @@ const toJs = async (tsScript: string): Promise<string> => {
     stdin: {
       contents: tsScript,
       resolveDir: __dirname,
-      loader: 'ts',
+      loader: 'ts'
     },
     bundle: true,
     write: false,
     format: 'esm',
     platform: 'browser',
-    target: 'es2017',
+    target: 'es2017'
   })
   const jsScript = buildResult.outputFiles[0]!.text
   return jsScript
@@ -66,19 +66,29 @@ export const test = async (port: number, logger: Logger) => {
     throw new Error(`Tunnel ${TUNNEL_ID} not found`)
   }
 
+  const pongPromise = new Promise<void>((resolve) => {
+    tunnelHead.events.once('pong', () => {
+      logger.info('received pong')
+      resolve()
+    })
+  })
+  tunnelHead.ping()
+
   tunnelHead.send({
     id: REQUEST_ID,
     method: 'GET',
     path: '/hello',
     headers: {},
-    body: REQUEST_BODY,
+    body: REQUEST_BODY
   })
 
   const serverExitPromise = server.wait().then(() => {
     throw new Error('Server exited')
   })
 
-  const response = await Promise.race([responsePromise, serverExitPromise])
+  const successPromise = Promise.all([responsePromise, pongPromise])
+
+  const [response] = await Promise.race([successPromise, serverExitPromise])
 
   await browser.close()
   server.close()

--- a/tunnel/e2e/browser/ts-script.ts
+++ b/tunnel/e2e/browser/ts-script.ts
@@ -17,9 +17,14 @@ const main = async () => {
         requestId: request.id,
         status: 200,
         headers: {},
-        body: RESPONSE_BODY,
+        body: RESPONSE_BODY
       })
       resolve()
+    })
+
+    tunnelTail.events.on('ping', () => {
+      console.info('received ping, sending pong...')
+      tunnelTail.pong()
     })
   })
 }

--- a/tunnel/src/types.ts
+++ b/tunnel/src/types.ts
@@ -10,7 +10,7 @@ export const tunnelRequestSchema = z.object({
   path: z.string(),
   query: z.string().optional(),
   headers: z.record(tunnelHeaderSchema).optional(),
-  body: z.string().optional(),
+  body: z.string().optional()
 })
 
 export type TunnelResponse = z.infer<typeof tunnelResponseSchema>
@@ -18,5 +18,11 @@ export const tunnelResponseSchema = z.object({
   requestId: z.string(),
   status: z.number(),
   headers: z.record(tunnelHeaderSchema).optional(),
-  body: z.string().optional(),
+  body: z.string().optional()
 })
+
+export type Ping = z.infer<typeof pingSchema>
+export const pingSchema = z.object({ type: z.literal('ping') })
+
+export type Pong = z.infer<typeof pongSchema>
+export const pongSchema = z.object({ type: z.literal('pong') })


### PR DESCRIPTION
- Sending pong's at regulare interval did solve the deconnection problem
- There alreay is a `.ping()` and a `.pong()` method on the websocket, altough you can only subscribe to such events in the nodejs implementation (the browser can't)
- I believe there is already something like a standard ping pong protocol supported by browsers: https://stackoverflow.com/questions/10585355/sending-websocket-ping-pong-frame-from-browser
- For these reasons, I decided to create my own ping-pong protocol
