### PR TITLE
feat(opapi): allow getting state without exporting it

### DIFF
--- a/opapi/package.json
+++ b/opapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/opapi",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/opapi/src/opapi.ts
+++ b/opapi/src/opapi.ts
@@ -45,6 +45,7 @@ const createOpapiFromState = <
   state: State<SchemaName, DefaultParameterName, SectionName>,
 ) => {
   return {
+    getState: (): State<SchemaName, DefaultParameterName, SectionName> => state,
     getModelRef: (name: SchemaName): OpenApiZodAny => getRef(state, ComponentType.SCHEMAS, name),
     addOperation: <Path extends string>(
       operationProps: Operation<DefaultParameterName, SectionName, Path, 'zod-schema'>,

--- a/opapi/src/state.ts
+++ b/opapi/src/state.ts
@@ -3,7 +3,7 @@ import { VError } from 'verror'
 import { z } from 'zod'
 import { schema } from './opapi'
 import type { PathParams } from './path-params'
-import { isAlphanumeric, isCapitalAlphabetical } from './util'
+import { isAlphanumeric, isCapitalAlphabetical, uniqueBy } from './util'
 import { generateSchemaFromZod } from './jsonschema'
 import { OpenApiZodAny } from '@anatine/zod-openapi'
 import { objects } from './objects'
@@ -255,17 +255,11 @@ export function createState<SchemaName extends string, DefaultParameterName exte
     refs.schemas[name] = true
   })
 
-  const errors = [unknownError, internalError, ...(props.errors ?? [])]
-
-  const existingErrors = new Set<string>()
+  const userErrors = props.errors ?? []
+  const defaultErrors = [unknownError, internalError]
+  const errors = uniqueBy([...defaultErrors, ...userErrors], 'type')
 
   errors.forEach((error) => {
-    if (existingErrors.has(error.type)) {
-      throw new VError(`Error ${error.type} already exists`)
-    }
-
-    existingErrors.add(error.type)
-
     if (!isCapitalAlphabetical(error.type)) {
       throw new VError(`Invalid error type ${error.type}. It must be alphabetical and start with a capital letter`)
     }

--- a/opapi/src/util.ts
+++ b/opapi/src/util.ts
@@ -22,3 +22,15 @@ export function removeFromArray(array: string[], item: string) {
     array.splice(index, 1)
   }
 }
+
+export function uniqueBy<T, K extends keyof T>(array: readonly T[], k: K): T[] {
+  const seen = new Set<T[K]>()
+  return array.filter((item) => {
+    const v = item[k]
+    if (seen.has(v)) {
+      return false
+    }
+    seen.add(v)
+    return true
+  })
+}


### PR DESCRIPTION
This will allow doing:

```ts
import { OpenApi } from '@bpinternal/opapi'
import { api } from '@botpress/api'

const { errors } = api.getState()

const chatApi = OpenApi({
  metadata: {
    description: '...',
    server: 'http://localhost:3000',
    title: '...',
    version: '0.0.0',
  },
  errors // simply reuse errors from the Botpress API
})
```

instead of:

```ts
// gen.ts
import { api } from '@botpress/api'
api.exportState("./gen")

// index.ts
import { state } from './gen'
const chatApi = OpenApi({
  metadata: {
    description: '...',
    server: 'http://localhost:3000',
    title: '...',
    version: '0.0.0',
  },
  errors: state.errors
})
```