### PR TITLE
feat(opapi): generate better error IDs

### DIFF
--- a/opapi/package.json
+++ b/opapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/opapi",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/opapi/src/generators/errors.ts
+++ b/opapi/src/generators/errors.ts
@@ -83,12 +83,24 @@ abstract class BaseApiError<Code extends ErrorCode, Type extends string, Descrip
   }
 
   static generateId() {
+    const prefix = this.getPrefix();
+    const timestamp = new Date().toISOString().replace(/[\:\-TZ]/g, "").split(".")[0] // UTC time in YYMMDDHHMMSS format
+
     const randomSuffixByteLength = 4
     const randomHexSuffix = Array.from(cryptoLib.getRandomValues(new Uint8Array(randomSuffixByteLength)))
       .map(x => x.toString(16).padStart(2, '0'))
       .join('')
       .toUpperCase()
-    return \`err_\${Date.now()}x\${randomHexSuffix}\`
+    
+    return \`\${prefix}_\${timestamp}x\${randomHexSuffix}\`
+  }
+
+  private static getPrefix() {
+    if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {
+      // Browser environment
+      return 'err_bwsr'
+    }
+    return 'err'
   }
 }
 


### PR DESCRIPTION
This PR makes the following improvements for the error IDs we generate:

- The embedded timestamp is now in YYYYMMDDHHMMSS format (UTC time) instead of a Unix epoch timestamp.
- If the error occurs in a browser environment, the prefix for the error ID will be `err_bwsr` instead of `err`, so we can easily identify errors that happened in the user's browser, so we can look them up in Sentry instead of Grafana.