### PR TITLE
feat(zui): Add UI Extensions to ZUI

### DIFF
--- a/zui/src/index.ts
+++ b/zui/src/index.ts
@@ -1,5 +1,5 @@
 export { getZuiSchemas } from './zui-schemas'
-export { zui } from './zui'
+export { zui, extendZod } from './zui'
 export type { ZuiType, Infer, ZuiExtension, ZuiRawShape, ZuiTypeAny } from './zui'
 export type { JsonSchema7Type as JsonSchema7 } from '@bpinternal/zod-to-json-schema/src/parseDef'
 export type { JsonFormElement } from './components'

--- a/zui/src/uiextensions.test.ts
+++ b/zui/src/uiextensions.test.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod'
+import { createComponent } from './uiextensions'
+import { extendZod } from './zui'
+import { describe, test } from 'vitest'
+
+const testExtensions = {
+  string: [
+    createComponent(
+      'SuperInput',
+      z.object({
+        allowVariables: z.boolean().optional(),
+      }),
+    ),
+  ],
+  number: [
+    createComponent(
+      'SuperNumber',
+      z.object({
+        min: z.number().optional(),
+        max: z.number().optional(),
+      }),
+    ),
+  ],
+  boolean: [
+    createComponent(
+      'SuperCheckbox',
+      z.object({
+        label: z.string().optional(),
+      }),
+    ),
+  ],
+  array: [
+    createComponent(
+      'SuperArray',
+      z.object({
+        minItems: z.number().optional(),
+        maxItems: z.number().optional(),
+      }),
+    ),
+  ],
+  object: [
+    createComponent(
+      'SuperObject',
+      z.object({
+        label: z.string().optional(),
+      }),
+    ),
+  ],
+}
+
+describe('ZUI UI Extensions', () => {
+  test('should be able to extend zod', () => {
+    const zui = extendZod<typeof testExtensions>(z)
+
+    zui.number().displayAs({
+      name: 'SuperNumber',
+      min: 0,
+      max: 100,
+    })
+  })
+})

--- a/zui/src/uiextensions/defaults.ts
+++ b/zui/src/uiextensions/defaults.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+import { createComponent } from '.'
+
+export const commonHTMLInputSchema = z.object({
+  id: z.string().optional(),
+  disabled: z.boolean().default(false).optional(),
+  readonly: z.boolean().default(false).optional(),
+  hidden: z.boolean().default(false).optional(),
+  autofocus: z.boolean().default(false).optional(),
+  required: z.boolean().default(false).optional(),
+})
+
+export const defaultExtensions = {
+  string: [
+    createComponent(
+      'html:input',
+      commonHTMLInputSchema.extend({
+        type: z.enum(['text', 'password', 'email', 'tel', 'url']).default('text'),
+        default: z.string().optional(),
+        maxLength: z.number().optional(),
+        minLength: z.number().optional(),
+        pattern: z.string().optional(),
+        placeholder: z.string().optional(),
+      }),
+    ),
+  ],
+  number: [
+    createComponent(
+      'html:numberinput',
+      commonHTMLInputSchema.extend({
+        type: z.enum(['number', 'range']).default('number'),
+        default: z.number().optional(),
+        min: z.number().optional(),
+        max: z.number().optional(),
+        step: z.number().optional(),
+      }),
+    ),
+  ],
+  boolean: [
+    createComponent(
+      'html:checkbox',
+      commonHTMLInputSchema.extend({
+        default: z.boolean().default(false).optional(),
+      }),
+    ),
+  ],
+  object: [],
+  array: [],
+} as const

--- a/zui/src/uiextensions/index.ts
+++ b/zui/src/uiextensions/index.ts
@@ -1,0 +1,29 @@
+import { ZodType, z } from 'zod'
+
+export const createComponent = <Name extends string, O extends z.Schema>(
+  name: Name,
+  options: O,
+): Component<Name, z.infer<O>> => ({
+  name,
+  ...options,
+})
+
+type BaseType = 'number' | 'string' | 'boolean' | 'object' | 'array'
+
+export type UIExtension = Record<BaseType, readonly Component<string, any>[]>
+
+export type Component<N, O> = {
+  name: N
+} & O
+
+export type ZodToBaseType<T extends ZodType> = T extends z.ZodString
+  ? 'string'
+  : T extends z.ZodBoolean
+  ? 'boolean'
+  : T extends z.ZodNumber
+  ? 'number'
+  : T extends z.ZodArray<any, any>
+  ? 'array'
+  : T extends z.ZodObject<any, any>
+  ? 'object'
+  : never

--- a/zui/src/zui-to-json-schema.ts
+++ b/zui/src/zui-to-json-schema.ts
@@ -6,7 +6,7 @@ import { zuiKey, ToZodType } from './zui'
 import type { ZuiSchemaOptions } from './zui-schemas'
 
 type JsonSchemaWithZui = JsonSchema7 & {
-  [zuiKey]?: ZuiExtension<ToZodType<ZuiTypeAny>>
+  [zuiKey]?: ZuiExtension<ToZodType<ZuiTypeAny>, any>
 }
 
 export const zuiToJsonSchema = (zuiType: ZuiTypeAny, opts: ZuiSchemaOptions): JsonSchemaWithZui => {
@@ -32,7 +32,7 @@ const mergeZuiIntoJsonSchema = (
   zuiSchema: ZuiType<any>,
   opts: ZuiSchemaOptions,
 ): JsonSchema7 => {
-  const assignZuiProps = (value: JsonSchemaWithZui, ui: ZuiExtension<ToZodType<ZuiTypeAny>>['ui']) => {
+  const assignZuiProps = (value: JsonSchemaWithZui, ui: ZuiExtension<ToZodType<ZuiTypeAny>, any>['ui']) => {
     if (ui?.examples) {
       Object.assign(value, { examples: ui.examples })
     }
@@ -47,7 +47,7 @@ const mergeZuiIntoJsonSchema = (
       const shape = zuiSchema?._def.shape?.()
 
       if (shape?.[key]) {
-        const innerZui = shape[key].ui as ZuiExtension<ToZodType<ZuiTypeAny>>['ui']
+        const innerZui = shape[key].ui as ZuiExtension<ToZodType<ZuiTypeAny>, any>['ui']
 
         assignZuiProps(value, innerZui)
         mergeZuiIntoJsonSchema(value, shape[key], opts)


### PR DESCRIPTION
Adds type safe extensible UI schemas to ZUI:

https://github.com/botpress/packages/assets/18604963/5d612cf8-6848-4d9e-b9f5-5a6c26dd30ab

Example usage:
```typescript
import { extendZod, createComponent } from 'zui'

const testExtensions = {
  string: [
    createComponent(
      'SuperInput',
      z.object({
        allowVariables: z.boolean().optional(),
      }),
    ),
  ],
  number: [],
  boolean: [],
  array: [],
  object: [],
}
const zui = extendZod<typeof testExtensions>(z)
```