### PR TITLE
feat(zui): Nested objects support

### DIFF
--- a/zui/README.md
+++ b/zui/README.md
@@ -10,7 +10,7 @@ import { zui, getZuiSchemas, jsonSchemaToZod } from '@bpinternal/zui'
 const objectSchema = zui.object({
   name: zui.string().title('Name').describe('Name of the user'),
   age: zui.number().min(0).max(100).title('Age').describe('Age in years'),
-  hobby: zui.string().title('Hobby').examples(['Skiing', 'Hiking', 'Swimming', 'Coding'])
+  hobby: zui.string().title('Hobby').examples(['Skiing', 'Hiking', 'Swimming', 'Coding']),
 })
 
 // schema: JSON Schema containing the additional properties under `x-zui`

--- a/zui/src/index.ts
+++ b/zui/src/index.ts
@@ -1,15 +1,5 @@
-export type {
-  UIExtension,
-  BaseType,
-  GlobalExtensionDefinition,
-  UIExtensionDefinition,
-} from './uiextensions'
-export {
-  type ZuiFormProps,
-  defaultComponentLibrary,
-  defaultExtensions,
-  ZuiForm,
-} from './react'
+export type { UIExtension, BaseType, GlobalExtensionDefinition, UIExtensionDefinition } from './uiextensions'
+export { type ZuiFormProps, defaultComponentLibrary, defaultExtensions, ZuiForm } from './react'
 export type { ZUIFieldComponent, ZUIContainerComponent, ZUIComponent, ZUIComponentLibrary } from './react/types'
 export type { Zui, ZuiType, Infer, ZuiExtension, ZuiRawShape, ZuiTypeAny } from './zui'
 export type {

--- a/zui/src/index.ts
+++ b/zui/src/index.ts
@@ -1,17 +1,16 @@
-export {
-  type UIExtension,
-  type BaseType,
-  type GlobalExtensionDefinition,
-  type UIExtensionDefinition,
-  defaultExtensions,
+export type {
+  UIExtension,
+  BaseType,
+  GlobalExtensionDefinition,
+  UIExtensionDefinition,
 } from './uiextensions'
 export {
-  type ZUIReactComponent,
-  type ZUIReactComponentLibrary,
   type ZuiFormProps,
   defaultComponentLibrary,
+  defaultExtensions,
   ZuiForm,
 } from './react'
+export type { ZUIFieldComponent, ZUIContainerComponent, ZUIComponent, ZUIComponentLibrary } from './react/types'
 export type { Zui, ZuiType, Infer, ZuiExtension, ZuiRawShape, ZuiTypeAny } from './zui'
 export type {
   JsonSchema7Type as JsonSchema7,

--- a/zui/src/react/defaults.tsx
+++ b/zui/src/react/defaults.tsx
@@ -30,10 +30,14 @@ export const defaultExtensions = {
       id: 'select',
       schema: commonHTMLInputSchema.extend({
         default: z.string().optional(),
-        options: z.array(z.object({
-          value: z.string(),
-          label: z.string(),
-        })).optional(),
+        options: z
+          .array(
+            z.object({
+              value: z.string(),
+              label: z.string(),
+            }),
+          )
+          .optional(),
       }),
     },
     datetimeinput: {
@@ -76,10 +80,8 @@ export const defaultExtensions = {
       }),
     },
   },
-  array: {
-  },
-  object: {
-  },
+  array: {},
+  object: {},
 } as const satisfies UIExtension
 
 const TextBox: ZUIComponent<'string', 'textbox', typeof defaultExtensions> = ({ params }) => {
@@ -127,15 +129,21 @@ export const defaultComponentLibrary: ZUIComponentLibrary<typeof defaultExtensio
   },
   array: {},
   object: {
-    default: ({ children }) => <div style={{
-      display: 'flex',
-      alignItems: 'stretch',
-      justifyContent: 'stretch',
-      flexDirection: 'column',
-      padding: '0.4rem',
-      margin: '0.2rem',
-      gap: '0.5rem',
-      boxSizing: 'border-box'
-    }}>{children}</div>,
+    default: ({ children }) => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'stretch',
+          justifyContent: 'stretch',
+          flexDirection: 'column',
+          padding: '0.4rem',
+          margin: '0.2rem',
+          gap: '0.5rem',
+          boxSizing: 'border-box',
+        }}
+      >
+        {children}
+      </div>
+    ),
   },
 }

--- a/zui/src/react/defaults.tsx
+++ b/zui/src/react/defaults.tsx
@@ -1,40 +1,121 @@
 import React from 'react'
-import type { ZUIReactComponentLibrary, ZUIReactComponent } from '.'
-import { defaultExtensions } from '../uiextensions'
+import { z } from 'zod'
+import type { ZUIComponentLibrary, ZUIComponent } from './types'
+import { UIExtension } from '../uiextensions'
 
-const TextBox: ZUIReactComponent<'string', 'textbox', typeof defaultExtensions> = ({ params }) => {
-  return <input {...params} />
+export const commonHTMLInputSchema = z.object({
+  name: z.string(),
+  id: z.string().optional(),
+  disabled: z.boolean().default(false).optional(),
+  readonly: z.boolean().default(false).optional(),
+  hidden: z.boolean().default(false).optional(),
+  autofocus: z.boolean().default(false).optional(),
+  required: z.boolean().default(false).optional(),
+  placeholder: z.string().optional(),
+})
+
+export const defaultExtensions = {
+  string: {
+    textbox: {
+      id: 'textbox',
+      schema: commonHTMLInputSchema.extend({
+        type: z.enum(['text', 'password', 'email', 'tel', 'url']).default('text'),
+        default: z.string().optional(),
+        maxLength: z.number().optional(),
+        minLength: z.number().optional(),
+        pattern: z.string().optional(),
+      }),
+    },
+    select: {
+      id: 'select',
+      schema: commonHTMLInputSchema.extend({
+        default: z.string().optional(),
+        options: z.array(z.object({
+          value: z.string(),
+          label: z.string(),
+        })).optional(),
+      }),
+    },
+    datetimeinput: {
+      id: 'datetimeinput',
+      schema: commonHTMLInputSchema.extend({
+        type: z.enum(['datetime-local', 'date', 'week']).default('datetime-local'),
+        default: z.string().optional(),
+        min: z.string().optional(),
+        max: z.string().optional(),
+      }),
+    },
+  },
+  number: {
+    numberinput: {
+      id: 'numberinput',
+      schema: commonHTMLInputSchema.extend({
+        type: z.literal('number'),
+        default: z.number().optional().default(0),
+        min: z.number().optional().default(0),
+        max: z.number().optional(),
+        step: z.number().default(0).optional(),
+      }),
+    },
+    slider: {
+      id: 'slider',
+      schema: commonHTMLInputSchema.extend({
+        type: z.literal('range'),
+        default: z.number().optional().default(0),
+        min: z.number().optional().default(0),
+        max: z.number().optional(),
+        step: z.number().default(0).optional(),
+      }),
+    },
+  },
+  boolean: {
+    checkbox: {
+      id: 'checkbox',
+      schema: commonHTMLInputSchema.extend({
+        default: z.boolean().default(false).optional(),
+      }),
+    },
+  },
+  array: {
+  },
+  object: {
+  },
+} as const satisfies UIExtension
+
+const TextBox: ZUIComponent<'string', 'textbox', typeof defaultExtensions> = ({ params }) => {
+  return <input style={{ display: 'flex' }} {...params} />
 }
 
-const NumberSlider: ZUIReactComponent<'number', 'slider', typeof defaultExtensions> = ({ params }) => {
-  return <input {...params} />
+const NumberSlider: ZUIComponent<'number', 'slider', typeof defaultExtensions> = ({ params }) => {
+  return <input style={{ display: 'flex' }} {...params} />
 }
 
-const DatetimeInput: ZUIReactComponent<'string', 'datetimeinput', typeof defaultExtensions> = ({ params }) => {
-  return <input {...params} />
+const DatetimeInput: ZUIComponent<'string', 'datetimeinput', typeof defaultExtensions> = ({ params }) => {
+  return <input style={{ display: 'flex' }} {...params} />
 }
 
-const NumberInput: ZUIReactComponent<'number', 'numberinput', typeof defaultExtensions> = ({ params }) => {
-  return <input {...params} />
+const NumberInput: ZUIComponent<'number', 'numberinput', typeof defaultExtensions> = ({ params }) => {
+  return <input style={{ display: 'flex' }} {...params} />
 }
 
-const BooleanCheckbox: ZUIReactComponent<'boolean', 'checkbox', typeof defaultExtensions> = ({ params }) => {
-  return <input {...params} />
+const BooleanCheckbox: ZUIComponent<'boolean', 'checkbox', typeof defaultExtensions> = ({ params }) => {
+  return <input style={{ display: 'flex' }} {...params} />
 }
 
-const SelectList: ZUIReactComponent<'array', 'select', typeof defaultExtensions> = ({ params }) => {
+const SelectList: ZUIComponent<'string', 'select', typeof defaultExtensions> = ({ params }) => {
   return (
-    <select {...params}>
-      {params.options.map((option) => (
+    <select {...params} defaultValue={params.default}>
+      {params.options?.map((option) => (
         <option value={option.value}>{option.label}</option>
       ))}
     </select>
   )
 }
 
-export const defaultComponentLibrary: ZUIReactComponentLibrary<typeof defaultExtensions> = {
+export const defaultComponentLibrary: ZUIComponentLibrary<typeof defaultExtensions> = {
   string: {
     textbox: TextBox,
+    select: SelectList,
     datetimeinput: DatetimeInput,
   },
   number: {
@@ -44,8 +125,17 @@ export const defaultComponentLibrary: ZUIReactComponentLibrary<typeof defaultExt
   boolean: {
     checkbox: BooleanCheckbox,
   },
-  array: {
-    select: SelectList,
+  array: {},
+  object: {
+    default: ({ children }) => <div style={{
+      display: 'flex',
+      alignItems: 'stretch',
+      justifyContent: 'stretch',
+      flexDirection: 'column',
+      padding: '0.4rem',
+      margin: '0.2rem',
+      gap: '0.5rem',
+      boxSizing: 'border-box'
+    }}>{children}</div>,
   },
-  object: {},
 }

--- a/zui/src/react/index.tsx
+++ b/zui/src/react/index.tsx
@@ -35,39 +35,55 @@ const resolveComponent = (components: ZUIComponentLibrary<any>, fieldSchema: any
   if (!uiDefinition || !Array.isArray(uiDefinition) || uiDefinition.length < 2) {
     const defaultComponent = components[type]?.default
     if (defaultComponent) {
-      return { Component: defaultComponent, type, id: 'default', params: {}, path, isContainer: containerTypes.includes(type as ContainerType)}
+      return {
+        Component: defaultComponent,
+        type,
+        id: 'default',
+        params: {},
+        path,
+        isContainer: containerTypes.includes(type as ContainerType),
+      }
     }
     return null
   }
 
   const componentID: string = uiDefinition[0] || 'default'
-  
+
   const Component = components[type]?.[componentID] || null
 
   if (!Component) {
     console.warn(`Component ${type}.${componentID} not found`)
     return null
   }
-  
+
   const params = uiDefinition[1] || {}
 
-  return { Component: Component as ZUIComponent<any, any>, type, id: componentID, params, path, isContainer: containerTypes.includes(type as ContainerType)}
+  return {
+    Component: Component as ZUIComponent<any, any>,
+    type,
+    id: componentID,
+    params,
+    path,
+    isContainer: containerTypes.includes(type as ContainerType),
+  }
 }
 
-
-export const ZuiForm = <T extends UIExtension = GlobalExtensionDefinition>({ schema, components }: ZuiFormProps<T>): JSX.Element | null => {
+export const ZuiForm = <T extends UIExtension = GlobalExtensionDefinition>({
+  schema,
+  components,
+}: ZuiFormProps<T>): JSX.Element | null => {
   const renderField = (fieldSchema: any, path: string[]) => {
-    const componentConfig = resolveComponent(components, fieldSchema, path);
+    const componentConfig = resolveComponent(components, fieldSchema, path)
 
     if (!componentConfig) {
-      return null;
+      return null
     }
 
-    const { Component, id, isContainer, path: currentPath, params, type } = componentConfig;
-    
+    const { Component, id, isContainer, path: currentPath, params, type } = componentConfig
+
     if (!Component) {
-      console.error(`Component not found for type: ${type} at path: ${path.join('.')}`);
-      return null;
+      console.error(`Component not found for type: ${type} at path: ${path.join('.')}`)
+      return null
     }
 
     return (
@@ -78,34 +94,30 @@ export const ZuiForm = <T extends UIExtension = GlobalExtensionDefinition>({ sch
         params={params}
         children={isContainer ? renderObjectFields(fieldSchema, currentPath) : undefined}
       />
-    );
-  };
+    )
+  }
 
   const renderObjectFields = (objectSchema: any, path: string[]): (JSX.Element | null)[] => {
-    const { properties } = objectSchema;
-    const fields: (JSX.Element | null)[] = [];
-    
+    const { properties } = objectSchema
+    const fields: (JSX.Element | null)[] = []
+
     for (const [fieldName, fieldSchema] of Object.entries(properties) as [string, any]) {
-      const fieldPath = [...path, fieldName];
+      const fieldPath = [...path, fieldName]
 
       if (!fieldSchema) {
-        console.error(`Field schema not found for field: ${fieldPath.join('.')}`);
-        continue;
+        console.error(`Field schema not found for field: ${fieldPath.join('.')}`)
+        continue
       }
 
-      const renderedField = renderField(fieldSchema, fieldPath);
+      const renderedField = renderField(fieldSchema, fieldPath)
 
-      fields.push(renderedField);
+      fields.push(renderedField)
     }
-    
-    return fields;
-  };
 
-  return (
-    <form>
-      {renderField(schema, [])}
-    </form>
-  );
-};
+    return fields
+  }
+
+  return <form>{renderField(schema, [])}</form>
+}
 
 export { defaultComponentLibrary, defaultExtensions } from './defaults'

--- a/zui/src/react/stories/ZuiForm.mdx
+++ b/zui/src/react/stories/ZuiForm.mdx
@@ -27,10 +27,7 @@ const exampleExtensions = {
     SuperCheckbox: { id: 'SuperCheckbox', schema: z.object({ label: z.string().optional() }) },
   },
   array: {
-    SuperArray: {
-      id: 'SuperArray',
-      schema: z.object({ minItems: z.number().optional(), maxItems: z.number().optional() }),
-    },
+    // not implemented yet
   },
   object: {
     SuperObject: { id: 'SuperObject', schema: z.object({ label: z.string().optional() }) },
@@ -52,9 +49,9 @@ Then, implement your custom components:
 
 ```typescript
 import React from 'react'
-import type { ZUIReactComponentLibrary, ZUIReactComponent } from 'zui'
+import type { ZUIReactComponentLibrary, ZUIComponent } from 'zui'
 
-const SuperInput: ZUIReactComponent<'string', 'SuperInput'> = ({ params }) => {
+const SuperInput: ZUIComponent<'string', 'SuperInput'> = ({ params }) => {
   return <input {...params} />
 }
 // ... other components

--- a/zui/src/react/stories/ZuiForm.stories.ts
+++ b/zui/src/react/stories/ZuiForm.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { ZuiForm, defaultComponentLibrary } from '..'
-import { defaultExtensions } from '../../uiextensions'
+import { ZuiForm, defaultComponentLibrary } from '../index'
 import { Zui, zui as zuiImport } from '../../zui'
+import { defaultExtensions } from '../defaults'
 
 const meta = {
   title: 'Form/Example',
@@ -54,6 +54,60 @@ const exampleSchema = zui.object({
     required: true,
     placeholder: 'Confirm Password',
   }),
+  planType: zui.string().displayAs('select', {
+    name: 'planType',
+    required: true,
+    default: 'premium',
+    options: [
+      { value: 'free', label: 'Free' },
+      { value: 'premium', label: 'Premium' },
+      { value: 'enterprise', label: 'Enterprise' }
+    ],
+  }).nonempty(),
+  location: zui.object({
+    street: zui.string().displayAs('textbox', {
+      name: 'street',
+      type: 'text',
+      required: true,
+      placeholder: 'Street',
+    }),
+    city: zui.string().displayAs('textbox', {
+      name: 'city',
+      type: 'text',
+      required: true,
+      placeholder: 'City',
+    }),
+    state: zui.string().displayAs('textbox', {
+      name: 'state',
+      type: 'text',
+      required: true,
+      placeholder: 'State',
+    }),
+    zip: zui.string().displayAs('textbox', {
+      name: 'zip',
+      type: 'text',
+      required: true,
+      placeholder: 'Zip',
+    }),
+    gps: zui.object({
+      lat: zui.number().displayAs('numberinput', {
+        name: 'lat',
+        type: 'number',
+        placeholder: 'Latitude',
+        required: true,
+        default: 0,
+        min: -90,
+      }),
+      lon: zui.number().displayAs('numberinput', {
+        name: 'lon',
+        type: 'number',
+        placeholder: 'Longitude',
+        required: true,
+        default: 0,
+        min: -180,
+      }),
+    })
+  })
 })
 
 export const ExampleSchema: Story = {

--- a/zui/src/react/stories/ZuiForm.stories.ts
+++ b/zui/src/react/stories/ZuiForm.stories.ts
@@ -54,16 +54,19 @@ const exampleSchema = zui.object({
     required: true,
     placeholder: 'Confirm Password',
   }),
-  planType: zui.string().displayAs('select', {
-    name: 'planType',
-    required: true,
-    default: 'premium',
-    options: [
-      { value: 'free', label: 'Free' },
-      { value: 'premium', label: 'Premium' },
-      { value: 'enterprise', label: 'Enterprise' }
-    ],
-  }).nonempty(),
+  planType: zui
+    .string()
+    .displayAs('select', {
+      name: 'planType',
+      required: true,
+      default: 'premium',
+      options: [
+        { value: 'free', label: 'Free' },
+        { value: 'premium', label: 'Premium' },
+        { value: 'enterprise', label: 'Enterprise' },
+      ],
+    })
+    .nonempty(),
   location: zui.object({
     street: zui.string().displayAs('textbox', {
       name: 'street',
@@ -106,8 +109,8 @@ const exampleSchema = zui.object({
         default: 0,
         min: -180,
       }),
-    })
-  })
+    }),
+  }),
 })
 
 export const ExampleSchema: Story = {

--- a/zui/src/react/types.ts
+++ b/zui/src/react/types.ts
@@ -1,0 +1,42 @@
+import type { FC } from 'react'
+import type { z } from 'zod'
+import type { BaseType, ContainerType, GlobalExtensionDefinition, UIExtension, containerTypes } from '../uiextensions'
+
+export type ZUIFieldComponent<
+  Type extends BaseType,
+  ID extends keyof UI[Type],
+  UI extends UIExtension = GlobalExtensionDefinition,
+> = FC<{
+  type: Type
+  id: ID
+  params: z.infer<UI[Type][ID]['schema']>
+}>
+
+export type ZUIContainerComponent<
+  Type extends BaseType,
+  ID extends keyof UI[Type],
+  UI extends UIExtension = GlobalExtensionDefinition,
+> = FC<{
+  type: Type
+  id: ID
+  params: z.infer<UI[Type][ID]['schema']>
+  children: React.ReactNode | React.ReactNode[] | null
+}>
+
+export type AsBaseType<T> = T extends BaseType ? T : never
+
+export type ZUIComponent<
+  Type extends BaseType,
+  ID extends keyof UI[Type],
+  UI extends UIExtension = GlobalExtensionDefinition,
+> = Type extends ContainerType
+  ? ZUIContainerComponent<AsBaseType<Type>, ID, UI>
+  : ZUIFieldComponent<AsBaseType<Type>, ID, UI>
+
+export type ZUIComponentLibrary<UI extends UIExtension = GlobalExtensionDefinition> = {
+  [Type in keyof UI]: {
+    [ID in keyof UI[Type]]: ZUIComponent<AsBaseType<Type>, ID, UI>
+  } & {
+    default?: ZUIComponent<AsBaseType<Type>, 'default', UI>
+  }
+}

--- a/zui/src/uiextensions.test.ts
+++ b/zui/src/uiextensions.test.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod'
 import { describe, test } from 'vitest'
 import { type Zui, zui as basezui } from './zui'
-import { type UIExtension, defaultExtensions } from './uiextensions'
+import { type UIExtension } from './uiextensions'
+import { defaultExtensions } from './react'
 
 const testExtensions = {
   string: {

--- a/zui/src/uiextensions.ts
+++ b/zui/src/uiextensions.ts
@@ -2,6 +2,9 @@ import { ZodSchema, ZodType, z } from 'zod'
 
 export type BaseType = 'number' | 'string' | 'boolean' | 'object' | 'array'
 
+export const containerTypes = ['object', 'array'] as const
+export type ContainerType = typeof containerTypes[number]
+
 export type UIExtension = {
   [type in BaseType]: {
     [id: string | number | symbol]: {
@@ -31,82 +34,3 @@ export type ZodToBaseType<T extends ZodType> = T extends z.ZodString
   ? 'object'
   : any
 
-export const commonHTMLInputSchema = z.object({
-  name: z.string(),
-  id: z.string().optional(),
-  disabled: z.boolean().default(false).optional(),
-  readonly: z.boolean().default(false).optional(),
-  hidden: z.boolean().default(false).optional(),
-  autofocus: z.boolean().default(false).optional(),
-  required: z.boolean().default(false).optional(),
-})
-
-export const defaultExtensions = {
-  string: {
-    textbox: {
-      id: 'textbox',
-      schema: commonHTMLInputSchema.extend({
-        type: z.enum(['text', 'password', 'email', 'tel', 'url']).default('text'),
-        default: z.string().optional(),
-        maxLength: z.number().optional(),
-        minLength: z.number().optional(),
-        pattern: z.string().optional(),
-        placeholder: z.string().optional(),
-      }),
-    },
-    datetimeinput: {
-      id: 'datetimeinput',
-      schema: commonHTMLInputSchema.extend({
-        type: z.enum(['datetime-local', 'date', 'week']).default('datetime-local'),
-        default: z.string().optional(),
-        min: z.string().optional(),
-        max: z.string().optional(),
-      }),
-    },
-  },
-  number: {
-    numberinput: {
-      id: 'numberinput',
-      schema: commonHTMLInputSchema.extend({
-        type: z.literal('number'),
-        default: z.number().optional().default(0),
-        min: z.number().optional().default(0),
-        max: z.number().optional(),
-        step: z.number().default(0).optional(),
-      }),
-    },
-    slider: {
-      id: 'slider',
-      schema: commonHTMLInputSchema.extend({
-        type: z.literal('range'),
-        default: z.number().optional().default(0),
-        min: z.number().optional().default(0),
-        max: z.number().optional(),
-        step: z.number().default(0).optional(),
-      }),
-    },
-  },
-  boolean: {
-    checkbox: {
-      id: 'checkbox',
-      schema: commonHTMLInputSchema.extend({
-        default: z.boolean().default(false).optional(),
-      }),
-    },
-  },
-  array: {
-    select: {
-      id: 'select',
-      schema: commonHTMLInputSchema.extend({
-        default: z.string().optional(),
-        options: z.array(
-          z.object({
-            label: z.string(),
-            value: z.string(),
-          }),
-        ),
-      }),
-    },
-  },
-  object: {},
-} as const satisfies UIExtension

--- a/zui/src/uiextensions.ts
+++ b/zui/src/uiextensions.ts
@@ -3,7 +3,7 @@ import { ZodSchema, ZodType, z } from 'zod'
 export type BaseType = 'number' | 'string' | 'boolean' | 'object' | 'array'
 
 export const containerTypes = ['object', 'array'] as const
-export type ContainerType = typeof containerTypes[number]
+export type ContainerType = (typeof containerTypes)[number]
 
 export type UIExtension = {
   [type in BaseType]: {
@@ -33,4 +33,3 @@ export type ZodToBaseType<T extends ZodType> = T extends z.ZodString
   : T extends z.ZodObject<any, any>
   ? 'object'
   : any
-

--- a/zui/tsup.config.ts
+++ b/zui/tsup.config.ts
@@ -11,5 +11,5 @@ export default defineConfig({
   clean: true,
   shims: true,
   noExternal: ['zod'],
-  bundle: true
+  bundle: true,
 })


### PR DESCRIPTION
- Adds support for showing nested objects and customizing containers of `object` types
- Adds an optional `default` field as fallback for handling unspecified `displayAs` in schemas

Example of nested objects:
```typescript
const exampleSchema = zui.object({
  firstName: zui.string().displayAs('textbox', {
    name: 'firstName',
    type: 'text',
    required: true,
    placeholder: 'First Name',
  }),
  // ...
  planType: zui.string().displayAs('select', {
    name: 'planType',
    required: true,
    default: 'premium',
    options: [
      { value: 'free', label: 'Free' },
      { value: 'premium', label: 'Premium' },
      { value: 'enterprise', label: 'Enterprise' }
    ],
  }).nonempty(),
  location: zui.object({
    street: zui.string().displayAs('textbox', {
      name: 'street',
      type: 'text',
      required: true,
      placeholder: 'Street',
    }),
    // ...
    gps: zui.object({
      lat: zui.number().displayAs('numberinput', {
        name: 'lat',
        type: 'number',
        placeholder: 'Latitude',
        required: true,
        default: 0,
        min: -90,
      }),
      lon: zui.number().displayAs('numberinput', {
        name: 'lon',
        type: 'number',
        placeholder: 'Longitude',
        required: true,
        default: 0,
        min: -180,
      }),
    })
  })
})
```
Gives:

![example](https://github.com/botpress/packages/assets/18604963/80e0d967-2036-4145-a23c-b1493b0f482b)

(red border added for clarity)
