### PR TITLE
feat(jex): extension check returns a reason on failure

### DIFF
--- a/jex/package.json
+++ b/jex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/jex",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "JSON-Extends; JSON Schema type checking library",
   "main": "dist/index.cjs",
   "types": "dist/src/index.d.ts",

--- a/jex/src/index.ts
+++ b/jex/src/index.ts
@@ -9,7 +9,7 @@ export const jsonSchemaEquals = async (a: JSONSchema7, b: JSONSchema7): Promise<
   return jex.jexEquals(jexA, jexB)
 }
 
-export const jsonSchemaExtends = async (child: JSONSchema7, parent: JSONSchema7): Promise<boolean> => {
+export const jsonSchemaExtends = async (child: JSONSchema7, parent: JSONSchema7): Promise<jex.JexExtensionResult> => {
   const jexChild = await jex.toJex(child)
   const jexParent = await jex.toJex(parent)
   return jex.jexExtends(jexChild, jexParent)

--- a/jex/src/jex-representation/jex-extends.test.ts
+++ b/jex/src/jex-representation/jex-extends.test.ts
@@ -9,12 +9,12 @@ const expectJex = (jexType: types.JexType) => ({
   not: {
     toExtend: (parent: types.JexType) => {
       const actual = jexExtends(jexType, parent)
-      expect(actual).toBe(false)
+      expect(actual).to.eq(false, `${JSON.stringify(jexType)} ⊆ ${JSON.stringify(parent)}`)
     }
   },
   toExtend: (parent: types.JexType) => {
     const actual = jexExtends(jexType, parent)
-    expect(actual).toBe(true)
+    expect(actual).to.eq(true, `${JSON.stringify(jexType)} ⊈ ${JSON.stringify(parent)}`)
   }
 })
 

--- a/jex/src/jex-representation/jex-extends.test.ts
+++ b/jex/src/jex-representation/jex-extends.test.ts
@@ -62,6 +62,9 @@ test('jex-extends should be true if child is an object with more properties than
 test('jex-extends should be false if child is an object with less properties than parent', () => {
   const child = $.object({ a: $.string() })
   const parent = $.object({ a: $.string(), b: $.number() })
+  type _child = JexInfer<typeof child>
+  type _parent = JexInfer<typeof parent>
+  type _childNotExtendsParent = utils.types.ExpectNot<utils.types.Extends<_child, _parent>>
   expectJex(child).not.toExtend(parent)
 })
 
@@ -69,6 +72,9 @@ test('jex-extends should be false if child is an object with less properties tha
 test('jex-extends should be false if an optional property of child is required in parent', () => {
   const child = $.object({ a: $.union([$.string(), $.undefined()]) })
   const parent = $.object({ a: $.string() })
+  type _child = JexInfer<typeof child>
+  type _parent = JexInfer<typeof parent>
+  type _childNotExtendsParent = utils.types.ExpectNot<utils.types.Extends<_child, _parent>>
   expectJex(child).not.toExtend(parent)
 })
 
@@ -103,6 +109,9 @@ test('jex-extends should be true if child is a literal with same base type than 
 test('jex-extends should be false if child is a primitive and parent is a literal', () => {
   const child = $.string()
   const parent = $.literal('banana')
+  type _child = JexInfer<typeof child>
+  type _parent = JexInfer<typeof parent>
+  type _childNotExtendsParent = utils.types.ExpectNot<utils.types.Extends<_child, _parent>>
   expectJex(child).not.toExtend(parent)
 })
 
@@ -120,6 +129,9 @@ test('jex-extends should be true if child is a literal included in parent union'
 test('jex-extends should be false if child is a literal not included in parent union', () => {
   const child = $.literal('banana')
   const parent = $.union([$.number(), $.literal('apple')])
+  type _child = JexInfer<typeof child>
+  type _parent = JexInfer<typeof parent>
+  type _childNotExtendsParent = utils.types.ExpectNot<utils.types.Extends<_child, _parent>>
   expectJex(child).not.toExtend(parent)
 })
 
@@ -137,6 +149,9 @@ test('jex-extends should be true if child and parents are arrays and child items
 test('jex-extends should be false if child and parents are arrays and child items do not extends parent items', () => {
   const child = $.array($.string())
   const parent = $.array($.number())
+  type _child = JexInfer<typeof child>
+  type _parent = JexInfer<typeof parent>
+  type _childNotExtendsParent = utils.types.ExpectNot<utils.types.Extends<_child, _parent>>
   expectJex(child).not.toExtend(parent)
 })
 
@@ -161,6 +176,9 @@ test('jex-extends should be true if child is a tuple and parent is an array with
 test('jex-extends should be false if child is a tuple and parent is an array with different items', () => {
   const child = $.tuple([$.string(), $.number()])
   const parent = $.array($.number())
+  type _child = JexInfer<typeof child>
+  type _parent = JexInfer<typeof parent>
+  type _childNotExtendsParent = utils.types.ExpectNot<utils.types.Extends<_child, _parent>>
   expectJex(child).not.toExtend(parent)
 })
 
@@ -188,5 +206,8 @@ test('jex-extends should be true if child and parents are maps and child items e
 test('jex-extends should be false if child and parents are maps and child items do not extends parent items', () => {
   const child = $.map($.union([$.string(), $.undefined(), $.boolean()]))
   const parent = $.map($.string())
+  type _child = JexInfer<typeof child>
+  type _parent = JexInfer<typeof parent>
+  type _childNotExtendsParent = utils.types.ExpectNot<utils.types.Extends<_child, _parent>>
   expectJex(child).not.toExtend(parent)
 })

--- a/jex/src/jex-representation/jex-extends.test.ts
+++ b/jex/src/jex-representation/jex-extends.test.ts
@@ -1,20 +1,32 @@
 import * as utils from '../utils'
 import { JexInfer } from './jex-infer'
 import * as types from './typings'
-import { jexExtends } from './jex-extends'
+import { JexExtensionResult, jexExtends } from './jex-extends'
 import { expect, test } from 'vitest'
 import { $ } from './jex-builder'
+import { toString } from './to-string'
 
-const expectJex = (jexType: types.JexType) => ({
+const SUBSET = `\u2286`
+
+const failureMessage = (res: JexExtensionResult): string => {
+  if (res.extends) return ''
+  return '\n' + res.reasons.map((r) => ` - ${r}\n`).join('')
+}
+
+const successMessage = (typeA: types.JexType, typeB: types.JexType): string => {
+  return `${toString(typeA)} ${SUBSET} ${toString(typeB)}`
+}
+
+const expectJex = (typeA: types.JexType) => ({
   not: {
-    toExtend: (parent: types.JexType) => {
-      const actual = jexExtends(jexType, parent)
-      expect(actual).to.eq(false, `${JSON.stringify(jexType)} ⊆ ${JSON.stringify(parent)}`)
+    toExtend: (typeB: types.JexType) => {
+      const actual = jexExtends(typeA, typeB)
+      expect(actual.extends).to.eq(false, successMessage(typeA, typeB))
     }
   },
-  toExtend: (parent: types.JexType) => {
-    const actual = jexExtends(jexType, parent)
-    expect(actual).to.eq(true, `${JSON.stringify(jexType)} ⊈ ${JSON.stringify(parent)}`)
+  toExtend: (typeB: types.JexType) => {
+    const actual = jexExtends(typeA, typeB)
+    expect(actual.extends).to.eq(true, failureMessage(actual))
   }
 })
 

--- a/jex/src/jex-representation/jex-extends.ts
+++ b/jex/src/jex-representation/jex-extends.ts
@@ -14,16 +14,13 @@ const _primitiveExtends = <T extends types.JexPrimitive>(child: T | LiteralOf<T>
   const _child = asPrimitive(child)
   const _parent = asPrimitive(parent)
 
-  if (_parent.value === undefined && _child.value === undefined) {
-    return true
+  if (_parent.value !== undefined && _child.value === undefined) {
+    return false
   }
-  if (_parent.value === undefined) {
-    return true
+  if (_parent.value !== undefined && _child.value !== _parent.value) {
+    return false
   }
-  if (_parent.value === _child.value) {
-    return true
-  }
-  return false
+  return true
 }
 
 export const jexExtends = (child: types.JexType, parent: types.JexType): boolean => {

--- a/jex/src/jex-representation/jex-extends.ts
+++ b/jex/src/jex-representation/jex-extends.ts
@@ -3,79 +3,77 @@ import { jexEquals } from './jex-equals'
 
 type LiteralOf<T extends types.JexPrimitive> = Extract<types.JexLiteral, { type: T['type'] }>
 
-const _primitiveExtends = <T extends types.JexPrimitive>(child: T | LiteralOf<T>, parent: types.JexType): boolean => {
-  const isT = (x: types.JexType): x is T | LiteralOf<T> => x.type === child.type
-  if (!isT(parent)) return false
+const _primitiveExtends = <T extends types.JexPrimitive>(typeA: T | LiteralOf<T>, typeB: types.JexType): boolean => {
+  const isT = (x: types.JexType): x is T | LiteralOf<T> => x.type === typeA.type
+  if (!isT(typeB)) return false
 
   type Primitive = LiteralOf<T> | (T & { value: undefined })
   const asPrimitive = (value: T | LiteralOf<T>): Primitive =>
     'value' in value ? value : { ...value, value: undefined }
 
-  const _child = asPrimitive(child)
-  const _parent = asPrimitive(parent)
+  const _typeA = asPrimitive(typeA)
+  const _typeB = asPrimitive(typeB)
 
-  if (_parent.value !== undefined && _child.value === undefined) {
+  if (_typeB.value !== undefined && _typeA.value === undefined) {
     return false
   }
-  if (_parent.value !== undefined && _child.value !== _parent.value) {
+  if (_typeB.value !== undefined && _typeA.value !== _typeB.value) {
     return false
   }
   return true
 }
 
-export const jexExtends = (child: types.JexType, parent: types.JexType): boolean => {
-  if (parent.type === 'any' || child.type === 'any') {
+export const jexExtends = (typeA: types.JexType, typeB: types.JexType): boolean => {
+  if (typeB.type === 'any' || typeA.type === 'any') {
     return true
   }
 
-  if (child.type === 'union') {
-    return child.anyOf.every((c) => jexExtends(c, parent))
+  if (typeA.type === 'union') {
+    return typeA.anyOf.every((c) => jexExtends(c, typeB))
   }
 
-  if (parent.type === 'union') {
-    return parent.anyOf.some((p) => jexExtends(child, p))
+  if (typeB.type === 'union') {
+    return typeB.anyOf.some((p) => jexExtends(typeA, p))
   }
 
-  if (child.type === 'object') {
-    if (parent.type === 'map') {
-      return Object.values(child.properties).every((c) => jexExtends(c, parent.items))
+  if (typeA.type === 'object') {
+    if (typeB.type === 'map') {
+      return Object.values(typeA.properties).every((c) => jexExtends(c, typeB.items))
     }
-    if (parent.type === 'object') {
-      return Object.entries(parent.properties).every(([key, parentValue]) => {
-        const childValue = child.properties[key]
-        if (childValue === undefined) return false
-        return jexExtends(childValue, parentValue)
+    if (typeB.type === 'object') {
+      return Object.entries(typeB.properties).every(([key, valueB]) => {
+        const valueA = typeA.properties[key]
+        if (valueA === undefined) return false
+        return jexExtends(valueA, valueB)
       })
     }
     return false
   }
 
-  if (child.type === 'map') {
-    if (parent.type !== 'map') return false
-    return jexExtends(child.items, parent.items)
+  if (typeA.type === 'map') {
+    if (typeB.type !== 'map') return false
+    return jexExtends(typeA.items, typeB.items)
   }
 
-  if (child.type === 'tuple') {
-    if (parent.type === 'array') {
-      return child.items.every((c) => jexExtends(c, parent.items))
+  if (typeA.type === 'tuple') {
+    if (typeB.type === 'array') {
+      return typeA.items.every((c) => jexExtends(c, typeB.items))
     }
-    if (parent.type === 'tuple') {
-      const zipped = child.items.map(
-        (c, i) => [c, parent.items[i]] satisfies [types.JexType, types.JexType | undefined]
-      )
+    if (typeB.type === 'tuple') {
+      const zipped = typeA.items.map((c, i) => [c, typeB.items[i]] satisfies [types.JexType, types.JexType | undefined])
       return zipped.every(([c, p]) => p === undefined || jexExtends(c, p))
     }
     return false
   }
 
-  if (child.type === 'array') {
-    if (parent.type !== 'array') return false
-    return jexExtends(child.items, parent.items)
+  if (typeA.type === 'array') {
+    if (typeB.type !== 'array') return false
+    return jexExtends(typeA.items, typeB.items)
   }
 
-  if (child.type === 'string' || child.type === 'number' || child.type === 'boolean') {
-    return _primitiveExtends(child, parent)
+  if (typeA.type === 'string' || typeA.type === 'number' || typeA.type === 'boolean') {
+    return _primitiveExtends(typeA, typeB)
   }
 
-  return jexEquals(child, parent)
+  return jexEquals(typeA, typeB)
 }

--- a/jex/src/jex-representation/property-path.test.ts
+++ b/jex/src/jex-representation/property-path.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from 'vitest'
+import { PropertyPath, PropertyPathSection, pathToString } from './property-path'
+
+const keyA: PropertyPathSection = { type: 'key', value: 'a' }
+const keyB: PropertyPathSection = { type: 'key', value: 'b' }
+const stringIndexBanana: PropertyPathSection = { type: 'string-index', value: 'banana' }
+const numberIndex0: PropertyPathSection = { type: 'number-index', value: 0 }
+const numberIndex: PropertyPathSection = { type: 'number-index' }
+const stringIndex: PropertyPathSection = { type: 'string-index' }
+
+const expectPath = (path: PropertyPath) => ({
+  toEqual: (expected: string) => {
+    const actual = pathToString(path)
+    expect(actual).to.eq(expected)
+  }
+})
+
+test('property path should correctly indicate which property is targeted', () => {
+  expectPath([]).toEqual('#')
+  expectPath([keyA]).toEqual('#.a')
+  expectPath([keyA, keyB]).toEqual('#.a.b')
+  expectPath([keyA, keyB, stringIndexBanana]).toEqual('#.a.b["banana"]')
+  expectPath([keyA, keyB, numberIndex0]).toEqual('#.a.b[0]')
+  expectPath([keyA, keyB, numberIndex]).toEqual('#.a.b[number]')
+  expectPath([keyA, keyB, stringIndex]).toEqual('#.a.b[string]')
+})

--- a/jex/src/jex-representation/property-path.ts
+++ b/jex/src/jex-representation/property-path.ts
@@ -1,0 +1,31 @@
+export type PropertyPathSection =
+  | {
+      type: 'string-index'
+      value?: string
+    }
+  | {
+      type: 'number-index'
+      value?: number
+    }
+  | {
+      type: 'key'
+      value: string
+    }
+
+export type PropertyPath = PropertyPathSection[]
+
+export const pathToString = (path: PropertyPath): string =>
+  '#' +
+  path
+    .map((section) => {
+      if (section.type === 'string-index') {
+        const value = section.value === undefined ? 'string' : `"${section.value}"`
+        return `[${value}]`
+      }
+      if (section.type === 'number-index') {
+        const value = section.value === undefined ? 'number' : section.value
+        return `[${value}]`
+      }
+      return `.${section.value}`
+    })
+    .join('')

--- a/jex/src/jex-representation/to-string.test.ts
+++ b/jex/src/jex-representation/to-string.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from 'vitest'
+import { toString } from './to-string'
+import { $ } from './jex-builder'
+import { JexType } from './typings'
+
+const expectJex = (jex: JexType) => ({
+  toStringifyAs: (expected: string) => {
+    const actual = toString(jex)
+    expect(actual).to.eq(expected)
+  }
+})
+
+test('should correctly convert jex schema to string representation', () => {
+  expectJex($.any()).toStringifyAs('any')
+  expectJex($.undefined()).toStringifyAs('undefined')
+  expectJex($.null()).toStringifyAs('null')
+  expectJex($.string()).toStringifyAs('string')
+  expectJex($.literal('hello')).toStringifyAs('"hello"')
+  expectJex($.number()).toStringifyAs('number')
+  expectJex($.literal(42)).toStringifyAs('42')
+  expectJex($.boolean()).toStringifyAs('boolean')
+  expectJex($.literal(true)).toStringifyAs('true')
+  expectJex($.array($.string())).toStringifyAs('string[]')
+  expectJex($.tuple([$.string(), $.number()])).toStringifyAs('[string, number]')
+  expectJex($.map($.number())).toStringifyAs('{ [key: string]: number }')
+  expectJex($.union([$.string(), $.number()])).toStringifyAs('string | number')
+  expectJex($.object({ a: $.string(), b: $.number() })).toStringifyAs('{ a: string, b: number }')
+
+  expectJex($.array($.union([$.string(), $.number()]))).toStringifyAs('(string | number)[]')
+})

--- a/jex/src/jex-representation/to-string.ts
+++ b/jex/src/jex-representation/to-string.ts
@@ -1,0 +1,43 @@
+import * as types from './typings'
+
+const _primitiveToString = (jexPrimitive: types.JexPrimitive): string => {
+  if ('value' in jexPrimitive) {
+    return JSON.stringify(jexPrimitive.value)
+  }
+  return jexPrimitive.type
+}
+
+export const toString = (jexSchema: types.JexType): string => {
+  if (jexSchema.type === 'undefined') return 'undefined'
+  if (jexSchema.type === 'null') return 'null'
+  if (jexSchema.type === 'string' || jexSchema.type === 'number' || jexSchema.type === 'boolean')
+    return _primitiveToString(jexSchema)
+
+  if (jexSchema.type === 'array') {
+    const itemIsUnion = jexSchema.items.type === 'union'
+    if (itemIsUnion) {
+      return `(${toString(jexSchema.items)})[]`
+    }
+    return `${toString(jexSchema.items)}[]`
+  }
+
+  if (jexSchema.type === 'tuple') {
+    return `[${jexSchema.items.map(toString).join(', ')}]`
+  }
+
+  if (jexSchema.type === 'map') {
+    return `{ [key: string]: ${toString(jexSchema.items)} }`
+  }
+
+  if (jexSchema.type === 'union') {
+    return jexSchema.anyOf.map(toString).join(' | ')
+  }
+
+  if (jexSchema.type === 'object') {
+    return `{ ${Object.entries(jexSchema.properties)
+      .map(([key, value]) => `${key}: ${toString(value)}`)
+      .join(', ')} }`
+  }
+
+  return 'any'
+}

--- a/jex/src/utils/type-utils.ts
+++ b/jex/src/utils/type-utils.ts
@@ -21,6 +21,7 @@ type _Tuple<T, N extends number, R extends any[]> = R['length'] extends N ? R : 
 export type Tuple<T, N extends number> = number extends N ? T[] : _Tuple<T, N, []>
 
 export type Expect<T extends true> = T extends true ? true : 'Expectation failed'
+export type ExpectNot<T extends false> = T extends false ? true : 'Expectation failed'
 
 export type Extends<T, U> = T extends U ? true : false
 


### PR DESCRIPTION
Example 1:
```
undefined ⊆ number ?
 - #: undefined ⊈ number

{a: string | undefined} ⊆ {a: string} ?
 - #.a: undefined ⊈ string

string | number | undefined | null ⊆ string | number ?
 - #: undefined ⊈ string
 - #: undefined ⊈ number
 - #: null ⊈ string
 - #: null ⊈ number

string ⊆ "banana" ?
 - #: string ⊈ "banana"

"banana" ⊆ number | "apple" ?
 - #: "banana" ⊈ number
 - #: "banana" ⊈ "apple"

string[] ⊆ number[] ?
 - #[number]: string ⊈ number

[string, number] ⊆ number[] ?
 - #[0]: string ⊈ number

Record<string, string | undefined | boolean> ⊆ Record<string, string> ?
 - #[string]: undefined ⊈ string
 - #[string]: boolean ⊈ string
```

Example 2:
```ts
import zodToJsonSchema from 'zod-to-json-schema'
import * as z from 'zod'
import * as jex from './src'
import { JSONSchema7 } from 'json-schema'

const z2j = (...args: Parameters<typeof zodToJsonSchema>) => zodToJsonSchema(...args) as JSONSchema7

const typeA = z2j(
  z.object({
    a: z.string(),
    b: z.tuple([
      z.any(),
      z.object({
        c: z.record(z.union([z.tuple([z.string(), z.number()]), z.object({ d: z.string() }), z.literal('e')]))
      })
    ])
  })
)

const typeB = z2j(
  z.object({
    a: z.string(),
    b: z.tuple([
      z.any(),
      z.object({
        c: z.record(z.union([z.tuple([z.string(), z.number()]), z.object({ d: z.string() })]))
      })
    ])
  })
)

jex.jsonSchemaExtends(typeA, typeB).then((extension) => console.log(extension))

// logs:
{
  extends: false,
  reasons: [
    '#.b[1].c[string]: "e" ⊈ [string, number]',
    '#.b[1].c[string]: "e" ⊈ { d: string }'
  ]
}
```
