### PR TITLE
fix(zui): empty prop are passtrough

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An extension of Zod for working nicely with UIs and JSON Schemas",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/object-to-zui.test.ts
+++ b/zui/src/object-to-zui.test.ts
@@ -145,4 +145,26 @@ describe('object-to-zui', () => {
     expect(schema.properties?.eventTime?.format).toBe('date-time')
     expect(schema.properties?.eventTime?.type).toBe('string')
   })
+
+  test('empty objects are considered passtrough, other are strict', () => {
+    const schema = zui.fromObject({ input: {}, test: { output: {} }, fixed: { value: true } }).toJsonSchema()
+
+    expect(schema).toHaveProperty('properties')
+    expect(Object.keys(schema.properties || {})).toHaveLength(3)
+    expect(schema.properties?.input).toHaveProperty('additionalProperties', true)
+    expect(schema.properties?.test).toHaveProperty('additionalProperties', false)
+    expect(schema.properties?.test?.properties?.output).toHaveProperty('additionalProperties', true)
+    expect(schema.properties?.fixed).toHaveProperty('additionalProperties', false)
+  })
+
+  test('when passtrough is set to true, they are all passtrough', () => {
+    const schema = zui
+      .fromObject({ input: {}, test: { output: {} }, fixed: { value: true } }, { passtrough: true })
+      .toJsonSchema()
+
+    expect(schema.properties?.input).toHaveProperty('additionalProperties', true)
+    expect(schema.properties?.test).toHaveProperty('additionalProperties', true)
+    expect(schema.properties?.test?.properties?.output).toHaveProperty('additionalProperties', true)
+    expect(schema.properties?.fixed).toHaveProperty('additionalProperties', true)
+  })
 })

--- a/zui/src/object-to-zui.ts
+++ b/zui/src/object-to-zui.ts
@@ -5,9 +5,9 @@ import { ZuiTypeAny, zui } from './zui'
 const dateTimeRegex =
   /^\d{4}-\d{2}-\d{2}(T|\s)?((\d{2}:\d{2}:\d{2}(\.\d{1,3})?)|(\d{2}:\d{2}))?(\s?([+-]\d{2}:\d{2}|Z))?$/
 
-export type ObjectToZuiOptions = { optional?: boolean; nullable?: boolean }
+export type ObjectToZuiOptions = { optional?: boolean; nullable?: boolean; passtrough?: boolean }
 
-export const objectToZui = (obj: any, opts?: ObjectToZuiOptions) => {
+export const objectToZui = (obj: any, opts?: ObjectToZuiOptions, isRoot = true) => {
   if (typeof obj !== 'object') {
     throw new Error('Input must be an object')
   }
@@ -19,6 +19,9 @@ export const objectToZui = (obj: any, opts?: ObjectToZuiOptions) => {
     }
     if (opts?.optional) {
       newType = newType.optional()
+    }
+    if (opts?.passtrough && typeof newType.passthrough === 'function') {
+      newType = newType.passthrough()
     }
     return newType
   }
@@ -42,12 +45,12 @@ export const objectToZui = (obj: any, opts?: ObjectToZuiOptions) => {
             if (value.length === 0) {
               acc[key] = applyOptions(zui.array(z.unknown()))
             } else if (typeof value[0] === 'object') {
-              acc[key] = applyOptions(zui.array(objectToZui(value[0], opts)))
+              acc[key] = applyOptions(zui.array(objectToZui(value[0], opts, false)))
             } else if (['string', 'number', 'boolean'].includes(typeof value[0])) {
               acc[key] = applyOptions(zui.array((zui as any)[typeof value[0] as any]()))
             }
           } else {
-            acc[key] = applyOptions(objectToZui(value, opts))
+            acc[key] = applyOptions(objectToZui(value, opts, false))
           }
           break
         default:
@@ -56,6 +59,11 @@ export const objectToZui = (obj: any, opts?: ObjectToZuiOptions) => {
     }
     return acc
   }, {} as ZuiTypeAny)
+
+  const hasProperties = Object.keys(schema).length > 0
+  if (opts?.passtrough || (!isRoot && !hasProperties)) {
+    return zui.object(schema).passthrough()
+  }
 
   return zui.object(schema)
 }


### PR DESCRIPTION
When creating a schema from `zui.fromObject({ field: 'test', input: {} })`, it's clear that input is intended to be passtrough. Also added an option to force it. 