### PR TITLE
chore(zui): Version 0.2.3

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "An extension of Zod for working nicely with UIs and JSON Schemas",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/index.ts
+++ b/zui/src/index.ts
@@ -1,6 +1,13 @@
 import { UIComponentDefinitions } from './ui/types'
 import { zui } from './zui'
-export type { BaseType, UIComponentDefinitions, SchemaResolversMap, ZuiComponentMap, AsBaseType } from './ui/types'
+export type {
+  BaseType,
+  UIComponentDefinitions,
+  SchemaResolversMap,
+  ZuiComponentMap,
+  AsBaseType,
+  ZuiReactComponent,
+} from './ui/types'
 export {
   type ZuiFormProps,
   ZuiForm,

--- a/zui/src/ui/index.tsx
+++ b/zui/src/ui/index.tsx
@@ -34,7 +34,7 @@ export type ZuiFormProps<UI extends UIComponentDefinitions = GlobalComponentDefi
   JsonFormsReactProps & {
     overrides?: SchemaResolversMap<UI>
     components: ZuiComponentMap<UI>
-    schema: JSONSchema | any
+    schema: JSONSchema | object | any
   }
 
 export const defaultControlResolver = (
@@ -311,13 +311,17 @@ export function ZuiForm<UI extends UIComponentDefinitions = GlobalComponentDefin
   overrides = {},
   components,
   ...jsonformprops
-}: ZuiFormProps<UI>): React.ReactNode | null {
+}: ZuiFormProps<UI>): JSX.Element | null {
   const renderers = useMemo(() => {
     return transformZuiComponentsToRenderers(components)
   }, [components])
 
   const uiSchema = useMemo(() => {
-    return schemaToUISchema<UI>(schema, overrides)
+    if (!schema) {
+      console.warn('Schema is nullish, skipping form rendering')
+      return null
+    }
+    return schemaToUISchema<UI>(schema as JSONSchema, overrides)
   }, [schema, overrides])
 
   if (!uiSchema) {

--- a/zui/src/ui/types.ts
+++ b/zui/src/ui/types.ts
@@ -231,7 +231,7 @@ export type ZuiReactLayoutComponentProps<
   ID extends keyof UI[Type],
   UI extends UIComponentDefinitions = GlobalComponentDefinitions,
 > = ZuiReactComponentBaseProps<Type, ID, UI> & {
-  children: any[]
+  children: JSX.Element | JSX.Element[]
 }
 
 export type ZuiReactControlComponentProps<

--- a/zui/tsup.config.ts
+++ b/zui/tsup.config.ts
@@ -11,5 +11,5 @@ export default defineConfig({
   clean: true,
   shims: true,
   noExternal: ['zod'],
-  bundle: true
+  bundle: true,
 })


### PR DESCRIPTION
- Add missing type export of `ZuiReactComponent` for specifying custom components
- Improved typing of input schema 
- Fixed React typings
- Handled empty or undefined schema rendering