### PR TITLE
feat(zui): Give access to full form state in component context params

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "An extension of Zod for working nicely with UIs and JSON Schemas",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/ui/types.ts
+++ b/zui/src/ui/types.ts
@@ -3,6 +3,7 @@ import type { Rule } from '@jsonforms/core'
 import { zuiKey } from '../zui'
 import { FC } from 'react'
 import { GlobalComponentDefinitions } from '..'
+import { JsonFormsStateContext } from '@jsonforms/react'
 
 export type ZuiSchemaExtension = {
   [zuiKey]: {
@@ -219,8 +220,10 @@ export type ZuiReactComponentBaseProps<
   context: {
     path: string
     uiSchema: Type extends ContainerType ? UILayoutSchema : UIControlSchema
-    renderers: any[]
-    cells: any[]
+    formErrors: NonNullable<JsonFormsStateContext['core']>['errors']
+    formData?: any
+    readonly: boolean
+    dispatch?: JsonFormsStateContext['dispatch']
   }
   i18nKeyPrefix?: string
   zuiProps: ZuiSchemaExtension[typeof zuiKey]


### PR DESCRIPTION
the `context` parameter now has access to the following:

- formData: the full form's current values
- formErrors: the full form's array of validation errors
- readonly: whether the whole form is set to readonly, defaults to false if undefined
- dispatch: The underlying dispatch function for JSON Form's state reducer

Remove access to cells and renderers as it is a JSON Form construct we are not using