### PR TITLE
feat(opapi): java client generator allows child classes to use inner client

### DIFF
--- a/opapi/package.json
+++ b/opapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/opapi",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/opapi/src/generators/client-java.ts
+++ b/opapi/src/generators/client-java.ts
@@ -34,7 +34,7 @@ import { errorFrom } from './errors'
 ${typeHelpers}
 
 export class ApiClient {
-  private _innerClient: DefaultApi
+  protected _innerClient: DefaultApi
   public constructor(configuration?: Configuration, basePath?: string, axiosInstance?: AxiosInstance) {
     this._innerClient = new DefaultApi(configuration, basePath, axiosInstance)
   }


### PR DESCRIPTION
this is for a files-api related feature in the public client, before we actually migrate to the new client generator