### PR TITLE
feat(limits): increase files_api_query_bytes to 2 KB

### DIFF
--- a/const/src/limits.ts
+++ b/const/src/limits.ts
@@ -82,11 +82,11 @@ export const limitConfigs = {
     unit: 'count'
   },
   files_api_query_bytes: {
-    value: 1024, // 1 KB
+    value: 2048, // 2 KB
     unit: 'bytes'
   },
   code_payload_bytes: {
     value: 52428800, // 50 MB
     unit: 'bytes'
-  },
+  }
 } as const satisfies Record<string, Limit>


### PR DESCRIPTION
The following errors have been found often in the logs:

```
2024-08-15 09:51:08.622	level=debug msg="LimitExceeded error handled as HTTP 413 response: Limit exceeded for files_api_query_bytes, attempted to use 1885 but maximum is 1024"
2024-08-15 09:38:44.029	level=debug msg="LimitExceeded error handled as HTTP 413 response: Limit exceeded for files_api_query_bytes, attempted to use 1082 but maximum is 1024"
```

Most of these over-the-limit queries appear to be below 2 KB so we'll increase the limit from the current 1 KB to 2 KB to accommodate for the majority of cases within a sane limit.