### PR TITLE
feat(zui): convert references to type arguments

### DIFF
--- a/zui/src/transforms/zui-to-typescript-next/index.test.ts
+++ b/zui/src/transforms/zui-to-typescript-next/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { UntitledDeclarationError, toTypescript as toTs } from '.'
+import { UnrepresentableGenericError, UntitledDeclarationError, toTypescript as toTs } from '.'
 import z, { ZodType } from '../../z'
 
 const toTypescript = (schema: ZodType): string => {
@@ -20,6 +20,24 @@ describe.concurrent('functions', () => {
     expect(() => toTs(fn, { declaration: true })).toThrowError(UntitledDeclarationError)
   })
 
+  it('type delcaration works', async () => {
+    const fn = z
+      .function()
+      .args(z.object({ a: z.number(), b: z.number() }))
+      .returns(z.number())
+      .title('add')
+      .describe('Add two numbers together.\nThis is a multiline description')
+
+    const typings = toTs(fn, { declaration: 'type' })
+    await expect(typings).toMatchWithoutFormatting(`
+      /**
+       * Add two numbers together.
+       * This is a multiline description
+       */
+        type add = (arg0: { a: number; b: number }) => number;
+      `)
+  })
+
   it('function with multi-line description', async () => {
     const fn = z
       .function()
@@ -35,7 +53,7 @@ describe.concurrent('functions', () => {
        * Add two numbers together.
        * This is a multiline description
        */
-      declare function add(arg0: { a: number; b: number }): number;
+      declare const add: (arg0: { a: number; b: number }) => number;
     `)
   })
 
@@ -44,7 +62,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
 
-    await expect(typings).toMatchWithoutFormatting('declare function fn(): unknown;')
+    await expect(typings).toMatchWithoutFormatting('declare const fn: () => unknown;')
   })
 
   it('function with no args and void return', async () => {
@@ -52,7 +70,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
 
-    await expect(typings).toMatchWithoutFormatting('declare function fn(): void;')
+    await expect(typings).toMatchWithoutFormatting('declare const fn: () => void;')
   })
 
   it('async function returning union', async () => {
@@ -63,7 +81,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
 
-    await expect(typings).toMatchWithoutFormatting('declare function fn(): Promise<number | string>;')
+    await expect(typings).toMatchWithoutFormatting('declare const fn: () => Promise<number | string>;')
   })
 
   it('function with multiple args', async () => {
@@ -82,7 +100,7 @@ describe.concurrent('functions', () => {
     const typings = toTypescript(fn)
 
     await expect(typings).toMatchWithoutFormatting(`
-      declare function fn(
+      declare const fn: (
         arg0: {
           a?: number;
           /** This is B parameter */
@@ -91,14 +109,14 @@ describe.concurrent('functions', () => {
         /** This is a number */
         arg1: number,
         arg2: [string, /** This is a number */ number]
-      ): unknown;
+      ) => unknown;
     `)
   })
 
   it('function with optional args', async () => {
     const fn = z.function().title('fn').args(z.string().optional())
     const typings = toTypescript(fn)
-    await expect(typings).toMatchWithoutFormatting('declare function fn(arg0?: string): unknown;')
+    await expect(typings).toMatchWithoutFormatting('declare const fn: (arg0?: string) => unknown;')
   })
 
   it('string literals', async () => {
@@ -162,7 +180,7 @@ describe.concurrent('functions', () => {
   it('function with named args', async () => {
     const fn = z.function().title('fn').args(z.string().title('firstName').optional())
     const typings = toTypescript(fn)
-    await expect(typings).toMatchWithoutFormatting('declare function fn(firstName?: string): unknown;')
+    await expect(typings).toMatchWithoutFormatting('declare const fn: (firstName?: string) => unknown;')
   })
 
   it('mix of named and unnammed params', async () => {
@@ -172,11 +190,11 @@ describe.concurrent('functions', () => {
       .args(z.string().title('firstName').optional(), z.number(), z.object({ a: z.string() }).title('obj'))
     const typings = toTypescript(fn)
     await expect(typings).toMatchWithoutFormatting(`
-        declare function fn(
+        declare const fn: (
           firstName?: string,
           arg1: number,
           obj: { a: string }
-        ): unknown;
+        ) => unknown;
       `)
   })
 
@@ -189,10 +207,10 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
     await expect(typings).toMatchWithoutFormatting(`
-      declare function fn(
+      declare const fn: (
         arg0?: string | null,
         arg1?: number
-      ): string | null | undefined;
+      ) => string | null | undefined;
     `)
   })
 })
@@ -201,6 +219,14 @@ describe.concurrent('objects', () => {
   it('title mandatory to declare', async () => {
     const obj = z.object({ a: z.number(), b: z.string() })
     expect(() => toTs(obj, { declaration: true })).toThrowError()
+  })
+
+  it('type declaration works', async () => {
+    const obj = z.object({ a: z.number(), b: z.string() }).title('MyObject')
+
+    const typings = toTs(obj, { declaration: 'type' })
+
+    await expect(typings).toMatchWithoutFormatting('type MyObject = { a: number; b: string };')
   })
 
   it('normal object', async () => {
@@ -461,7 +487,7 @@ describe.concurrent('objects', () => {
     const typings = toTypescript(fn)
 
     await expect(typings).toMatchWithoutFormatting(
-      'declare function MyObject(arg0: Array<{ a: number; b: string }>): unknown;',
+      'declare const MyObject: (arg0: Array<{ a: number; b: string }>) => unknown;',
     )
   })
 
@@ -470,10 +496,10 @@ describe.concurrent('objects', () => {
     const typings = toTypescript(fn)
 
     await expect(typings).toMatchWithoutFormatting(`
-        declare function MyObject(
+        declare const MyObject: (
           /** This is an array of numbers */
           arg0: number[]
-        ): unknown;
+        ) => unknown;
       `)
   })
 
@@ -547,5 +573,29 @@ describe.concurrent('objects', () => {
           }
         `
     await expect(typings).toMatchWithoutFormatting(expected)
+  })
+})
+
+describe.concurrent('generics', () => {
+  it("can't generate a generic type without type declaration", async () => {
+    const schema = z.object({ a: z.string(), b: z.ref('T') }).title('MyObject')
+    expect(() => toTs(schema, { declaration: true })).toThrowError(UnrepresentableGenericError)
+    expect(() => toTs(schema, { declaration: false })).toThrowError(UnrepresentableGenericError)
+    expect(() => toTs(schema, { declaration: 'reference' })).toThrowError(UnrepresentableGenericError)
+    expect(() => toTs(schema, { declaration: 'none' })).toThrowError(UnrepresentableGenericError)
+  })
+
+  it('can generate a generic type', async () => {
+    const schema = z.object({ a: z.string(), b: z.ref('T') }).title('MyObject')
+    const typings = toTs(schema, { declaration: 'type' })
+
+    await expect(typings).toMatchWithoutFormatting('type MyObject<T> = { a: string; b: T };')
+  })
+
+  it('can generate a generic type by formating ref Uri', async () => {
+    const schema = z.object({ a: z.string(), b: z.ref('#/$defs/T') }).title('MyObject')
+    const typings = toTs(schema, { declaration: 'type' })
+
+    await expect(typings).toMatchWithoutFormatting('type MyObject<DefsT> = { a: string; b: DefsT };')
   })
 })

--- a/zui/src/transforms/zui-to-typescript-next/index.test.ts
+++ b/zui/src/transforms/zui-to-typescript-next/index.test.ts
@@ -581,7 +581,7 @@ describe.concurrent('generics', () => {
     const schema = z.object({ a: z.string(), b: z.ref('T') }).title('MyObject')
     expect(() => toTs(schema, { declaration: true })).toThrowError(UnrepresentableGenericError)
     expect(() => toTs(schema, { declaration: false })).toThrowError(UnrepresentableGenericError)
-    expect(() => toTs(schema, { declaration: 'reference' })).toThrowError(UnrepresentableGenericError)
+    expect(() => toTs(schema, { declaration: 'variable' })).toThrowError(UnrepresentableGenericError)
     expect(() => toTs(schema, { declaration: 'none' })).toThrowError(UnrepresentableGenericError)
   })
 

--- a/zui/src/transforms/zui-to-typescript-next/index.ts
+++ b/zui/src/transforms/zui-to-typescript-next/index.ts
@@ -67,7 +67,7 @@ class Declaration {
 
 type DeclarationProps =
   | {
-      type: 'reference'
+      type: 'variable'
       schema: z.Schema
       identifier: string
     }
@@ -357,7 +357,7 @@ const unwrapDeclaration = (declaration: Declaration, options: InternalOptions): 
   const withoutDesc = declaration.props.schema.describe('')
   const typings = sUnwrapZod(withoutDesc, options)
 
-  if (declaration.props.type === 'reference') {
+  if (declaration.props.type === 'variable') {
     return stripSpaces(`${description}declare const ${declaration.props.identifier}: ${typings};`)
   }
 
@@ -371,7 +371,7 @@ const getDeclarationType = (options: TypescriptGenerationOptions): TypescriptDec
     return 'none'
   }
   if (options.declaration === true) {
-    return 'reference'
+    return 'variable'
   }
   return options.declaration
 }
@@ -395,14 +395,14 @@ const getDeclarationProps = (schema: z.Schema, options: TypescriptGenerationOpti
     throw new UntitledDeclarationError('Only schemas with "title" Zui property can be declared.')
   }
 
-  if (declarationType === 'reference') {
+  if (declarationType === 'variable') {
     if (args.length > 0) {
       throw new UnrepresentableGenericError(
         'ZodRefs are only supported when generating "type" declaration. Please set "declaration" option to "type".',
       )
     }
 
-    return new Declaration({ type: 'reference', identifier: title, schema })
+    return new Declaration({ type: 'variable', identifier: title, schema })
   }
 
   return new Declaration({ type: 'type', identifier: title, schema, args })

--- a/zui/src/transforms/zui-to-typescript-next/index.ts
+++ b/zui/src/transforms/zui-to-typescript-next/index.ts
@@ -1,5 +1,5 @@
 import z, { util } from '../../z'
-import { escapeString, getMultilineComment, toPropertyKey } from './utils'
+import { escapeString, getMultilineComment, toPropertyKey, toTypeArgumentName } from './utils'
 
 const Primitives = [
   'string',
@@ -16,7 +16,9 @@ const Primitives = [
   'object',
 ]
 
-export class UntitledDeclarationError extends Error {
+export abstract class ZuiToTypescriptError extends Error {}
+
+export class UntitledDeclarationError extends ZuiToTypescriptError {
   constructor(message: string) {
     super(message)
     this.name = 'UntitledDeclarationError'
@@ -24,6 +26,17 @@ export class UntitledDeclarationError extends Error {
 
   static isUntitledDeclarationError(err: Error): err is UntitledDeclarationError {
     return err.name === 'UntitledDeclarationError'
+  }
+}
+
+export class UnrepresentableGenericError extends ZuiToTypescriptError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UnrepresentableGenericError'
+  }
+
+  static isUnrepresentableGenericError(err: Error): err is UnrepresentableGenericError {
+    return err.name === 'UnrepresentableGenericError'
   }
 }
 
@@ -49,41 +62,43 @@ class FnReturn {
 }
 
 class Declaration {
-  constructor(
-    public schema: z.Schema,
-    public identifier: string,
-  ) {}
+  constructor(public props: DeclarationProps) {}
 }
 
+type DeclarationProps =
+  | {
+      type: 'reference'
+      schema: z.Schema
+      identifier: string
+    }
+  | {
+      type: 'type'
+      schema: z.Schema
+      identifier: string
+      args: string[] // type arguments / generics
+    }
+  | {
+      type: 'none'
+      schema: z.Schema
+    }
+
+export type TypescriptDeclarationType = DeclarationProps['type']
 export type TypescriptGenerationOptions = {
-  declaration?: boolean
   formatter?: (typing: string) => string
+} & {
+  declaration?: boolean | TypescriptDeclarationType
 }
 
 type SchemaTypes = z.Schema | KeyValue | FnParameters | Declaration | null
 
-type InternalOptions = TypescriptGenerationOptions & {
+type InternalOptions = {
   parent?: SchemaTypes
 }
 
-export function toTypescript(schema: z.Schema, options?: TypescriptGenerationOptions): string {
-  options ??= {}
-  options.declaration ??= false
+export function toTypescript(schema: z.Schema, options: TypescriptGenerationOptions = {}): string {
+  const wrappedSchema: Declaration = getDeclarationProps(schema, options)
 
-  let wrappedSchema: z.Schema | Declaration = schema
-
-  if (options?.declaration) {
-    if (schema instanceof z.Schema) {
-      const title = 'title' in schema.ui ? (schema.ui.title as string) : null
-      if (!title) {
-        throw new UntitledDeclarationError('Only schemas with "title" Zui property can be declared.')
-      }
-
-      wrappedSchema = new Declaration(schema, title)
-    }
-  }
-
-  let dts = sUnwrapZod(wrappedSchema, { ...options })
+  let dts = sUnwrapZod(wrappedSchema, {})
 
   if (options.formatter) {
     dts = options.formatter(dts)
@@ -93,27 +108,17 @@ export function toTypescript(schema: z.Schema, options?: TypescriptGenerationOpt
 }
 
 function sUnwrapZod(schema: z.Schema | KeyValue | FnParameters | Declaration | null, config: InternalOptions): string {
-  const newConfig = {
+  const newConfig: InternalOptions = {
     ...config,
-    declaration: false,
     parent: schema,
   }
+
   if (schema === null) {
     return ''
   }
 
   if (schema instanceof Declaration) {
-    const description = getMultilineComment(schema.schema.description)
-    const withoutDesc = schema.schema.describe('')
-    const typings = sUnwrapZod(withoutDesc, { ...newConfig, declaration: true })
-
-    if (schema.schema instanceof z.ZodFunction) {
-      return stripSpaces(`${description}
-declare function ${schema.identifier}${typings};`)
-    }
-
-    return stripSpaces(`${description}
-declare const ${schema.identifier}: ${typings};`)
+    return unwrapDeclaration(schema, newConfig)
   }
 
   if (schema instanceof KeyValue) {
@@ -266,11 +271,6 @@ ${opts.join(' | ')}`
       const input = sUnwrapZod(new FnParameters(def.args), newConfig)
       const output = sUnwrapZod(new FnReturn(def.returns), newConfig)
 
-      if (config?.declaration) {
-        return `${getMultilineComment(def.description)}
-(${input}): ${output}`
-      }
-
       return `${getMultilineComment(def.description)}
 (${input}) => ${output}`
 
@@ -296,22 +296,10 @@ ${value}`.trim()
       return sUnwrapZod(def.values, newConfig)
 
     case z.ZodFirstPartyTypeKind.ZodOptional:
-      if (config?.declaration || config?.parent instanceof z.ZodRecord || config?.parent instanceof z.ZodObject) {
-        return `${sUnwrapZod(def.innerType, newConfig)} | undefined`
-      }
-
-      if (
-        config?.parent instanceof z.ZodDefault ||
-        config?.parent instanceof z.ZodNullable ||
-        config?.parent instanceof z.ZodOptional
-      ) {
-        return `${sUnwrapZod(def.innerType, newConfig)} | undefined`
-      }
-
-      return `${sUnwrapZod(def.innerType, newConfig)}?`
+      return `${sUnwrapZod(def.innerType, newConfig)} | undefined`
 
     case z.ZodFirstPartyTypeKind.ZodNullable:
-      return `${sUnwrapZod((schema as z.ZodNullable<any>).unwrap(), newConfig)} | null`
+      return `${sUnwrapZod(def.innerType, newConfig)} | null`
 
     case z.ZodFirstPartyTypeKind.ZodDefault:
       return sUnwrapZod(def.innerType, newConfig)
@@ -335,8 +323,7 @@ ${value}`.trim()
       return `readonly ${sUnwrapZod(def.innerType, newConfig)}`
 
     case z.ZodFirstPartyTypeKind.ZodRef:
-      // TODO: should be represented as a type argument <T>
-      throw new Error('ZodRef cannot be transformed to TypeScript yet')
+      return toTypeArgumentName(def.uri)
 
     case z.ZodFirstPartyTypeKind.ZodTemplateLiteral:
       const inner = def.parts
@@ -350,7 +337,7 @@ ${value}`.trim()
           if (typeof p === 'boolean' || typeof p === 'number') {
             return `${p}`
           }
-          return '${' + sUnwrapZod(p, { ...newConfig, declaration: false }) + '}'
+          return '${' + sUnwrapZod(p, { ...newConfig }) + '}'
         })
         .join('')
 
@@ -359,4 +346,64 @@ ${value}`.trim()
     default:
       util.assertNever(def)
   }
+}
+
+const unwrapDeclaration = (declaration: Declaration, options: InternalOptions): string => {
+  if (declaration.props.type === 'none') {
+    return sUnwrapZod(declaration.props.schema, options)
+  }
+
+  const description = getMultilineComment(declaration.props.schema.description)
+  const withoutDesc = declaration.props.schema.describe('')
+  const typings = sUnwrapZod(withoutDesc, options)
+
+  if (declaration.props.type === 'reference') {
+    return stripSpaces(`${description}declare const ${declaration.props.identifier}: ${typings};`)
+  }
+
+  const generics =
+    declaration.props.args.length > 0 ? `<${declaration.props.args.map(toTypeArgumentName).join(', ')}>` : ''
+  return stripSpaces(`${description}type ${declaration.props.identifier}${generics} = ${typings};`)
+}
+
+const getDeclarationType = (options: TypescriptGenerationOptions): TypescriptDeclarationType => {
+  if (!options.declaration) {
+    return 'none'
+  }
+  if (options.declaration === true) {
+    return 'reference'
+  }
+  return options.declaration
+}
+
+const getDeclarationProps = (schema: z.Schema, options: TypescriptGenerationOptions): Declaration => {
+  const declarationType = getDeclarationType(options)
+  const args = schema.getReferences()
+
+  if (declarationType === 'none') {
+    if (args.length > 0) {
+      throw new UnrepresentableGenericError(
+        'ZodRefs are only supported when generating "type" declaration. Please set "declaration" option to "type".',
+      )
+    }
+
+    return new Declaration({ type: 'none', schema })
+  }
+
+  const title = 'title' in schema.ui ? (schema.ui.title as string) : null
+  if (!title) {
+    throw new UntitledDeclarationError('Only schemas with "title" Zui property can be declared.')
+  }
+
+  if (declarationType === 'reference') {
+    if (args.length > 0) {
+      throw new UnrepresentableGenericError(
+        'ZodRefs are only supported when generating "type" declaration. Please set "declaration" option to "type".',
+      )
+    }
+
+    return new Declaration({ type: 'reference', identifier: title, schema })
+  }
+
+  return new Declaration({ type: 'type', identifier: title, schema, args })
 }

--- a/zui/src/transforms/zui-to-typescript-next/utils.test.ts
+++ b/zui/src/transforms/zui-to-typescript-next/utils.test.ts
@@ -1,6 +1,6 @@
 import { isValidTypescript } from '../../setup.test'
 import { expect } from 'vitest'
-import { escapeString } from './utils'
+import { escapeString, toTypeArgumentName } from './utils'
 
 describe('Typescript Checker', () => {
   it('passes successfully on valid string definition', () => {
@@ -76,5 +76,18 @@ Hey world
       \`\`\`
       ""
     `)
+  })
+})
+
+describe('toTypeArgumentName', () => {
+  it('converts a valid key to a property key', () => {
+    expect(toTypeArgumentName('T')).toBe('T')
+    expect(toTypeArgumentName('TName')).toBe('TName')
+  })
+
+  it('converts an invalid key to a property key', () => {
+    expect(toTypeArgumentName('T-Name')).toBe('TName')
+    expect(toTypeArgumentName('t Name')).toBe('TName')
+    expect(toTypeArgumentName('#/t/Name')).toBe('TName')
   })
 })

--- a/zui/src/transforms/zui-to-typescript-next/utils.ts
+++ b/zui/src/transforms/zui-to-typescript-next/utils.ts
@@ -26,6 +26,17 @@ export const toPropertyKey = (key: string) => {
   return escapeString(key)
 }
 
+const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1)
+
+export const toTypeArgumentName = (name: string) => {
+  const nonAlphaNumeric = /[^a-zA-Z0-9_]/g
+  const tokens = name
+    .split(nonAlphaNumeric)
+    .map(capitalize)
+    .filter((t) => !!t)
+  return tokens.join('')
+}
+
 export const getMultilineComment = (description?: string) => {
   const descLines = (description ?? '').split('\n').filter((l) => l.trim().length > 0)
   return descLines.length === 0


### PR DESCRIPTION
This PR does 3 things:

1. replace all function declarations by arrow functions declaration, for simplicity:
```ts
// before
declare function add(x: number, y: number): number
// after
declare const add: (x: number, y: number) => number
```
2. allow declaring type instead of variable:
```ts
// with { declaration: true } or { declaration: "variable" }
declare const add: (x: number, y: number) => number
// with { declaration: "type" }
type add = (x: number, y: number) => number
```
3. allow generating a generic type from a zui ref
```ts
const schema = z.object({ foo: z.ref("T") }).title("X")
type X<T> = { foo: T }
```