### PR TITLE
feat(jex): replace any by unknown

### DIFF
--- a/jex/src/builders/jexir-builder.ts
+++ b/jex/src/builders/jexir-builder.ts
@@ -17,7 +17,7 @@ function _literal(value: string | number | boolean) {
 
 export type jexirBuilder = typeof jexirBuilder
 export const jexirBuilder = {
-  any: () => ({ type: 'any' }),
+  unknown: () => ({ type: 'unknown' }),
   string: () => ({ type: 'string' }),
   number: () => ({ type: 'number' }),
   boolean: () => ({ type: 'boolean' }),

--- a/jex/src/builders/json-schema-builder.ts
+++ b/jex/src/builders/json-schema-builder.ts
@@ -18,7 +18,7 @@ const INTEGER = { type: 'integer' } satisfies JSONSchema7
 const BOOLEAN = { type: 'boolean' } satisfies JSONSchema7
 const NULL = { type: 'null' } satisfies JSONSchema7
 const UNDEFINED = { not: {} } satisfies JSONSchema7
-const ANY = {} satisfies JSONSchema7
+const UNKOWN = {} satisfies JSONSchema7
 
 export type JsonSchemaBuilder = typeof jsonSchemaBuilder
 export const jsonSchemaBuilder = {
@@ -28,7 +28,7 @@ export const jsonSchemaBuilder = {
   boolean: () => BOOLEAN,
   null: () => NULL,
   undefined: () => UNDEFINED,
-  any: () => ANY,
+  unknown: () => UNKOWN,
   object: <K extends string>(
     properties: Record<K, JSONSchema7>,
     required: NoInfer<K>[] = Object.keys(properties) as K[]

--- a/jex/src/builders/json-schema-builder.ts
+++ b/jex/src/builders/json-schema-builder.ts
@@ -18,7 +18,7 @@ const INTEGER = { type: 'integer' } satisfies JSONSchema7
 const BOOLEAN = { type: 'boolean' } satisfies JSONSchema7
 const NULL = { type: 'null' } satisfies JSONSchema7
 const UNDEFINED = { not: {} } satisfies JSONSchema7
-const UNKOWN = {} satisfies JSONSchema7
+const UNKNOWN = {} satisfies JSONSchema7
 
 export type JsonSchemaBuilder = typeof jsonSchemaBuilder
 export const jsonSchemaBuilder = {
@@ -28,7 +28,7 @@ export const jsonSchemaBuilder = {
   boolean: () => BOOLEAN,
   null: () => NULL,
   undefined: () => UNDEFINED,
-  unknown: () => UNKOWN,
+  unknown: () => UNKNOWN,
   object: <K extends string>(
     properties: Record<K, JSONSchema7>,
     required: NoInfer<K>[] = Object.keys(properties) as K[]

--- a/jex/src/jex-extends.test.ts
+++ b/jex/src/jex-extends.test.ts
@@ -25,11 +25,15 @@ const expectJex = (typeA: jexir.JexIR) => ({
   }
 })
 
-// any extends string, string extends any, any extends any
-test('jex-extends should be true if child or parent is any', () => {
-  expectJex($.any()).toExtend($.any())
-  expectJex($.string()).toExtend($.any())
-  expectJex($.any()).toExtend($.string())
+// string extends unknown, unknown extends unknown
+test('jex-extends should be true if child or parent is unknown', () => {
+  expectJex($.unknown()).toExtend($.unknown())
+  expectJex($.string()).toExtend($.unknown())
+})
+
+// unknown does not extend string
+test('jex-extends should be false if child is unknown and parent is not', () => {
+  expectJex($.unknown()).not.toExtend($.string())
 })
 
 // string extends string, { a: string } extends { a: string }, etc..

--- a/jex/src/jex-extends.ts
+++ b/jex/src/jex-extends.ts
@@ -57,8 +57,13 @@ const _primitiveExtends = <T extends jexir.JexIRPrimitive>(
 }
 
 const _jexExtends = (path: PropertyPath, typeA: jexir.JexIR, typeB: jexir.JexIR): _JexExtensionResult => {
-  if (typeB.type === 'any' || typeA.type === 'any') {
-    return { result: true }
+  if (typeB.type === 'unknown') {
+    return { result: true } // everything extends unknown
+  }
+
+  if (typeA.type === 'unknown') {
+    // nothing extends unknown except unknown itself
+    return { result: false, reasons: [{ path, typeA, typeB }] }
   }
 
   if (typeA.type === 'union') {

--- a/jex/src/jexir/from-json-schema.test.ts
+++ b/jex/src/jexir/from-json-schema.test.ts
@@ -132,8 +132,8 @@ test('JexIR should model map types', async () => {
   })
 })
 
-test('JexIR should model any type', async () => {
-  await expectZod($.any()).toEqualJex({ type: 'any' })
+test('JexIR should model unknown type', async () => {
+  await expectZod($.unknown()).toEqualJex({ type: 'unknown' })
 })
 
 test('JexIR should model tuple types', async () => {

--- a/jex/src/jexir/from-json-schema.ts
+++ b/jex/src/jexir/from-json-schema.ts
@@ -71,7 +71,7 @@ const _toInternalRep = (schema: JSONSchema7): types.JexIR => {
   if (schema.not !== undefined) {
     if (schema.not === true) {
       return {
-        type: 'any'
+        type: 'unknown'
       }
     }
 
@@ -82,7 +82,7 @@ const _toInternalRep = (schema: JSONSchema7): types.JexIR => {
     }
 
     const not = _toInternalRep(schema.not)
-    if (not.type === 'any') {
+    if (not.type === 'unknown') {
       return {
         type: 'undefined'
       }
@@ -119,7 +119,7 @@ const _toInternalRep = (schema: JSONSchema7): types.JexIR => {
     if (schema.items === undefined) {
       return {
         type: 'array',
-        items: { type: 'any' }
+        items: { type: 'unknown' }
       }
     }
 
@@ -149,7 +149,7 @@ const _toInternalRep = (schema: JSONSchema7): types.JexIR => {
       if (schema.additionalProperties === true) {
         return {
           type: 'map',
-          items: { type: 'any' }
+          items: { type: 'unknown' }
         }
       }
       if (schema.additionalProperties === false) {
@@ -208,7 +208,7 @@ const _toInternalRep = (schema: JSONSchema7): types.JexIR => {
     }
   }
 
-  return { type: 'any' }
+  return { type: 'unknown' }
 }
 
 export const fromJsonSchema = async (schema: JSONSchema7): Promise<types.JexIR> => {

--- a/jex/src/jexir/to-json-schema.test.ts
+++ b/jex/src/jexir/to-json-schema.test.ts
@@ -132,10 +132,10 @@ test('JexIR of map types should map to json-schema', () => {
   })
 })
 
-// JexIR of any type should map to json-schema
+// JexIR of unknown type should map to json-schema
 
-test('JexIR of any type should map to json-schema', () => {
-  expectJex($.any()).toEqualJsonSchema({})
+test('JexIR of unknown type should map to json-schema', () => {
+  expectJex($.unknown()).toEqualJsonSchema({})
 })
 
 // JexIR of tuple types should map to json-schema

--- a/jex/src/jexir/to-string.test.ts
+++ b/jex/src/jexir/to-string.test.ts
@@ -11,7 +11,7 @@ const expectJex = (jex: JexIR) => ({
 })
 
 test('jexir toString should correctly convert jexir schema to string representation', () => {
-  expectJex($.any()).toStringifyAs('any')
+  expectJex($.unknown()).toStringifyAs('unknown')
   expectJex($.undefined()).toStringifyAs('undefined')
   expectJex($.null()).toStringifyAs('null')
   expectJex($.string()).toStringifyAs('string')

--- a/jex/src/jexir/to-string.ts
+++ b/jex/src/jexir/to-string.ts
@@ -44,5 +44,5 @@ export const toString = (jexirSchema: types.JexIR): string => {
       .join(', ')} }`
   }
 
-  return 'any'
+  return 'unknown'
 }

--- a/jex/src/jexir/typings.ts
+++ b/jex/src/jexir/typings.ts
@@ -60,8 +60,8 @@ export type JexIRMap = {
   items: JexIR
 }
 
-export type JexIRAny = {
-  type: 'any'
+export type JexIRUnkown = {
+  type: 'unknown'
 }
 
 export type JexIRTuple = {
@@ -85,5 +85,5 @@ export type JexIR =
   | JexIRObject
   | JexIRArray
   | JexIRMap
-  | JexIRAny
+  | JexIRUnkown
   | JexIRTuple

--- a/jex/src/jexir/typings.ts
+++ b/jex/src/jexir/typings.ts
@@ -60,7 +60,7 @@ export type JexIRMap = {
   items: JexIR
 }
 
-export type JexIRUnkown = {
+export type JexIRUnknown = {
   type: 'unknown'
 }
 
@@ -85,5 +85,5 @@ export type JexIR =
   | JexIRObject
   | JexIRArray
   | JexIRMap
-  | JexIRUnkown
+  | JexIRUnknown
   | JexIRTuple


### PR DESCRIPTION
In typescript,`any` is equivalent to a `// @ts-ignore` indicator. It tells typescript not to check the type.

In JSON Schema, `any` does not exist. An empty schema means a schema with no constraints or in other words, any kind of data. An empty schema should thus be treated like unknown; i.e. the most global type. 

This way, `unknown ⊈ string`, but `string ⊆ unknown`