### PR TITLE
chore: standardize code workspaces in packages

### DIFF
--- a/const/index.code-workspace
+++ b/const/index.code-workspace
@@ -1,5 +1,9 @@
 {
-  "folders": [{ "path": "./jex" }],
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
   "settings": {
     "typescript.tsdk": "node_modules/typescript/lib"
   }

--- a/depsynky/index.code-workspace
+++ b/depsynky/index.code-workspace
@@ -1,5 +1,9 @@
 {
-  "folders": [{ "path": "./zui" }],
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
   "settings": {
     "typescript.tsdk": "node_modules/typescript/lib"
   }

--- a/entities/index.code-workspace
+++ b/entities/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/es-node/index.code-workspace
+++ b/es-node/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/expresso/index.code-workspace
+++ b/expresso/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/genenv/index.code-workspace
+++ b/genenv/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/jex/index.code-workspace
+++ b/jex/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/log4bot/index.code-workspace
+++ b/log4bot/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/opapi/index.code-workspace
+++ b/opapi/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/promex/index.code-workspace
+++ b/promex/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/ptb-schema/index.code-workspace
+++ b/ptb-schema/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/readiness/index.code-workspace
+++ b/readiness/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/trail/index.code-workspace
+++ b/trail/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/tunnel/index.code-workspace
+++ b/tunnel/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/verel/index.code-workspace
+++ b/verel/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/yargs-extra/index.code-workspace
+++ b/yargs-extra/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}

--- a/zui/index.code-workspace
+++ b/zui/index.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "typescript.tsdk": "node_modules/typescript/lib"
+  }
+}


### PR DESCRIPTION
In each and every package, there is a `index.code-workspace` file that you can open. Doing so will only open the desired package in vscode. You can then have different vscode settings for each packages without messing up the git tab