### PR TITLE
fix(zui): fix typescript generation for .readonly() types

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/transforms/zui-to-typescript-type/index.test.ts
+++ b/zui/src/transforms/zui-to-typescript-type/index.test.ts
@@ -120,6 +120,18 @@ describe.concurrent('functions', () => {
     await expect(typings).toMatchWithoutFormatting('declare const fn: (arg0?: string) => unknown;')
   })
 
+  it('function with readonly args', async () => {
+    const fn = z.function().title('fn').args(z.string().readonly())
+    const typings = toTypescript(fn)
+    await expect(typings).toMatchWithoutFormatting('declare const fn: (arg0: Readonly<string>) => unknown;')
+  })
+
+  it('function with readonly enumerable args', async () => {
+    const fn = z.function().title('fn').args(z.array(z.string()).readonly())
+    const typings = toTypescript(fn)
+    await expect(typings).toMatchWithoutFormatting('declare const fn: (arg0: Readonly<string[]>) => unknown;')
+  })
+
   it('string literals', async () => {
     const typings = toTypescript(
       z
@@ -327,6 +339,40 @@ describe.concurrent('objects', () => {
     const typings = toTypescript(obj)
 
     await expect(typings).toMatchWithoutFormatting('declare const MyObject: { address: {} | null };')
+  })
+
+  it('object with a description & readonly', async () => {
+    const obj = z
+      .object({
+        someStr: z.string().describe('Description').readonly(),
+      })
+      .title('MyObject')
+
+    const typings = toTypescript(obj)
+
+    await expect(typings).toMatchWithoutFormatting(`
+        declare const MyObject: {
+          /** Description */
+          someStr: Readonly<string>
+        };
+      `)
+  })
+
+  it('object with readonly and a description (opposite of previous test)', async () => {
+    const obj = z
+      .object({
+        someStr: z.string().readonly().describe('Description'),
+      })
+      .title('MyObject')
+
+    const typings = toTypescript(obj)
+
+    await expect(typings).toMatchWithoutFormatting(`
+        declare const MyObject: {
+          /** Description */
+          someStr: Readonly<string>
+        };
+      `)
   })
 
   it('zod record', async () => {

--- a/zui/src/transforms/zui-to-typescript-type/primitives.test.ts
+++ b/zui/src/transforms/zui-to-typescript-type/primitives.test.ts
@@ -17,7 +17,16 @@ function getTypingVariations(type: z.ZodType, opts?: { declaration?: boolean; ma
 
   const typingsOptionalNullable = toTypescript(type.optional().nullable(), opts)
 
-  const output = [baseTypings, typingsNullable, typingsOptional, typingsNullableOptional, typingsOptionalNullable]
+  const typingsReadonly = toTypescript(type.readonly(), opts)
+
+  const output = [
+    baseTypings,
+    typingsNullable,
+    typingsOptional,
+    typingsNullableOptional,
+    typingsOptionalNullable,
+    typingsReadonly,
+  ]
 
   return output
 }


### PR DESCRIPTION
- the first commit contains the actual fix
- the second commit is born from my frustration trying to follow the and understand the logic in index.ts. the file has been refactored to split up large functions and give more descriptive names to stuff. there's still a lot more that could be done, such as splitting into several meaningfully-named files, but for now I believe it's an improvement