### PR TITLE
chore(verel): disable browser tests

### DIFF
--- a/verel/package.json
+++ b/verel/package.json
@@ -7,12 +7,13 @@
   "types": "./dist/types/index.d.ts",
   "scripts": {
     "postinstall": "pnpm exec playwright install",
+    "check": "pnpm run check:type",
     "check:type": "tsc --noEmit",
     "build": "pnpm run build:node && pnpm run build:web && pnpm run build:type",
     "build:type": "tsc -p tsconfig.build.json",
     "build:node": "ts-node -T ./build.ts nodejs",
     "build:web": "ts-node -T ./build.ts web",
-    "test": "pnpm run test:node && pnpm run test:browser",
+    "test": "pnpm run test:node",
     "test:node": "vitest --browser.enabled false --run",
     "test:browser": "vitest --browser.enabled true --run"
   },
@@ -29,7 +30,7 @@
     "lodash": "^4.17.21",
     "playwright": "^1.47.2",
     "ts-node": "^10.9.1",
-    "typescript": "5.6.2",
+    "typescript": "5.6.3",
     "vitest": "^2.1.1",
     "wasm-pack": "^0.13.0"
   },

--- a/verel/pnpm-lock.yaml
+++ b/verel/pnpm-lock.yaml
@@ -18,7 +18,7 @@ devDependencies:
     version: 20.8.9
   '@vitest/browser':
     specifier: ^2.1.1
-    version: 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.2)(vitest@2.1.2)
+    version: 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.3)(vitest@2.1.2)
   esbuild:
     specifier: ^0.24.0
     version: 0.24.0
@@ -30,10 +30,10 @@ devDependencies:
     version: 1.47.2
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.2(@types/node@20.8.9)(typescript@5.6.2)
+    version: 10.9.2(@types/node@20.8.9)(typescript@5.6.3)
   typescript:
-    specifier: 5.6.2
-    version: 5.6.2
+    specifier: 5.6.3
+    version: 5.6.3
   vitest:
     specifier: ^2.1.1
     version: 2.1.2(@types/node@20.8.9)(@vitest/browser@2.1.2)
@@ -827,7 +827,7 @@ packages:
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
     dev: true
 
-  /@vitest/browser@2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.2)(vitest@2.1.2):
+  /@vitest/browser@2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.3)(vitest@2.1.2):
     resolution: {integrity: sha512-tqpGfz2sfjFFNuZ2iLZ6EGRVnH8z18O93ZIicbLsxDhiLgRNz84UcjSvX4pbheuddW+BJeNbLGdM3BU8vohbEg==}
     peerDependencies:
       playwright: '*'
@@ -847,7 +847,7 @@ packages:
       '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.4.9)
       '@vitest/utils': 2.1.2
       magic-string: 0.30.11
-      msw: 2.4.9(typescript@5.6.2)
+      msw: 2.4.9(typescript@5.6.3)
       playwright: 1.47.2
       sirv: 2.0.4
       tinyrainbow: 1.2.0
@@ -885,7 +885,7 @@ packages:
       '@vitest/spy': 2.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.11
-      msw: 2.4.9(typescript@5.6.2)
+      msw: 2.4.9(typescript@5.6.3)
     dev: true
 
   /@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(vite@5.4.8):
@@ -1401,7 +1401,7 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
-  /msw@2.4.9(typescript@5.6.2):
+  /msw@2.4.9(typescript@5.6.3):
     resolution: {integrity: sha512-1m8xccT6ipN4PTqLinPwmzhxQREuxaEJYdx4nIbggxP8aM7r1e71vE7RtOUSQoAm1LydjGfZKy7370XD/tsuYg==}
     engines: {node: '>=18'}
     hasBin: true
@@ -1428,7 +1428,7 @@ packages:
       path-to-regexp: 6.3.0
       strict-event-emitter: 0.5.1
       type-fest: 4.26.1
-      typescript: 5.6.2
+      typescript: 5.6.3
       yargs: 17.7.2
     dev: true
 
@@ -1693,7 +1693,7 @@ packages:
       url-parse: 1.5.10
     dev: true
 
-  /ts-node@10.9.2(@types/node@20.8.9)(typescript@5.6.2):
+  /ts-node@10.9.2(@types/node@20.8.9)(typescript@5.6.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -1719,7 +1719,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.6.2
+      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -1734,8 +1734,8 @@ packages:
     engines: {node: '>=16'}
     dev: true
 
-  /typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+  /typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -1850,7 +1850,7 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.8.9
-      '@vitest/browser': 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.2)(vitest@2.1.2)
+      '@vitest/browser': 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.3)(vitest@2.1.2)
       '@vitest/expect': 2.1.2
       '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.8)
       '@vitest/pretty-format': 2.1.2


### PR DESCRIPTION
Browser tests keep failing with error:
```
WebAssembly.Compile is disallowed on the main thread, if the buffer size is larger than 8MB. Use WebAssembly.compile, compile on a worker thread, or use the flag `--enable-features=WebAssemblyUnlimitedSyncCompilation`.
```

I have little time to dig deeper into that + we don't currently use verel in the browser because its too big anyway