### PR TITLE
chore(zui): drastically improve zui test speed by removing toBeValidTypescript custom expect

### DIFF
--- a/zui/src/setup.test.ts
+++ b/zui/src/setup.test.ts
@@ -1,36 +1,5 @@
 import { expect } from 'vitest'
-import { Project, Diagnostic } from 'ts-morph'
 import { format } from 'prettier'
-
-export function isValidTypescript(
-  code: string,
-): { isValid: true } | { isValid: false; diagnostics: Diagnostic[]; errorMessage: string } {
-  const project = new Project({})
-  try {
-    project.createSourceFile('test.ts', code)
-    const diags = project.getPreEmitDiagnostics()
-    if (diags.length) {
-      return { isValid: false, diagnostics: diags, errorMessage: project.formatDiagnosticsWithColorAndContext(diags) }
-    }
-    return { isValid: true }
-  } catch (e: any) {
-    return { isValid: false, diagnostics: [], errorMessage: e?.message || '' }
-  }
-}
-
-expect.extend({
-  toBeValidTypeScript(received: string) {
-    const { isNot } = this
-    const validation = isValidTypescript(received)
-
-    return {
-      pass: validation.isValid,
-      message: () => {
-        return `Expected code to ${isNot ? 'not ' : ''}be valid TypeScript:\n${received}\n\n${validation.isValid ? '' : validation.errorMessage}`
-      },
-    }
-  },
-})
 
 const formatTs = async (code: string): Promise<string> => {
   code = code.replace(/\s+/g, ' ')

--- a/zui/src/transforms/common/utils.test.ts
+++ b/zui/src/transforms/common/utils.test.ts
@@ -1,52 +1,5 @@
-import { isValidTypescript } from '../../setup.test'
 import { expect } from 'vitest'
 import { toTypeArgumentName, primitiveToTypescriptValue } from './utils'
-
-describe('Typescript Checker', () => {
-  it('passes successfully on valid string definition', () => {
-    const data = isValidTypescript(`const a: string = 'hello'`)
-
-    expect(data.isValid).toBe(true)
-  })
-
-  it('fails correctly on invalid code', () => {
-    const data = isValidTypescript(`const a: string = 1`)
-    expect(data.isValid).toBe(false)
-  })
-
-  it('can handle Error types', () => {
-    const data = isValidTypescript(`const a: Error = new Error('hello')`)
-    expect(data.isValid).toBe(true)
-  })
-
-  it('can handle promises', () => {
-    const data = isValidTypescript(`const a: Promise<string> = Promise.resolve('hello')`)
-    expect(data.isValid).toBe(true)
-  })
-})
-
-describe('test utility to validate typescript', () => {
-  it('passes on valid code', () => {
-    const exampleTS = `
-const a: string = 'hello'
-const b: number = 1
-const c: string[] = ['hello']
-const d: { a: string } = { a: 'hello' }
-const e: { a: string }[] = [{ a: 'hello' }]`
-    expect(exampleTS).toBeValidTypeScript()
-  })
-
-  it('fails on invalid code', () => {
-    const invalidTS = `
-const a: string = 1
-const b: number = 'hello'
-const c: string[] = [1]
-const d: { a: string } = { a: 1 }
-
-  })`
-    expect(invalidTS).not.toBeValidTypeScript()
-  })
-})
 
 describe('primitiveToTypscriptLiteral', () => {
   it('converts a string to a valid typescript string value', () => {

--- a/zui/src/transforms/zui-to-typescript-type/index.test.ts
+++ b/zui/src/transforms/zui-to-typescript-type/index.test.ts
@@ -500,7 +500,38 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    expect(typings).toBeValidTypeScript() // TODO: change that to a proper `toMatchWithoutFormatting` check
+    await expect(typings).toMatchWithoutFormatting(`
+      declare const payment:
+        | {
+            type: 'Credit Card';
+            /** This is the card number */
+            cardNumber: string;
+            /** This is the expiration date */
+            expirationDate: string;
+            /** This is the brand of the card */
+            brand?: 'Visa' | 'Mastercard' | 'American Express' | null | undefined;
+          }
+        | {
+            type: 'PayPal';
+            /** This is the paypal account's email address */
+            email: string;
+          }
+        | {
+            type: 'Bitcoin';
+            /** This is the bitcoin address */
+            address: string;
+          }
+        | {
+            type: 'Bank Transfer';
+            /** This is the bank account number */
+            accountNumber: string;
+          }
+        | {
+            type: 'Cash';
+            /** This is the amount of cash */
+            amount: number;
+          }
+    `)
   })
 
   it('zod lazy', async () => {

--- a/zui/src/transforms/zui-to-typescript-type/index.ts
+++ b/zui/src/transforms/zui-to-typescript-type/index.ts
@@ -215,10 +215,7 @@ function sUnwrapZod(schema: z.Schema | KeyValue | FnParameters | Declaration | n
 
     case z.ZodFirstPartyTypeKind.ZodObject:
       const props = Object.entries(def.shape()).map(([key, value]) => {
-        if (value instanceof z.Schema) {
-          return sUnwrapZod(new KeyValue(toPropertyKey(key), value), newConfig)
-        }
-        return `${key}: unknown`
+        return sUnwrapZod(new KeyValue(toPropertyKey(key), value), newConfig)
       })
 
       return `{ ${props.join('; ')} }`

--- a/zui/src/transforms/zui-to-typescript-type/primitives.test.ts
+++ b/zui/src/transforms/zui-to-typescript-type/primitives.test.ts
@@ -1,106 +1,231 @@
-import { describe, it, expect } from 'vitest'
+import { test, expect } from 'vitest'
 import { toTypescript } from '.'
 import z from '../../z'
 
-/**
- * This test file is excessively slow due to the `toBeValidTypeScript` custom matcher.
- */
+const toTypescriptType = (schema: z.Schema) => toTypescript(schema, { declaration: 'variable' })
 
-function getTypingVariations(type: z.ZodType, opts?: { declaration?: boolean; maxDepth?: number }): string[] {
-  const baseTypings = toTypescript(type, opts)
-
-  const typingsNullable = toTypescript(type.nullable(), opts)
-
-  const typingsOptional = toTypescript(type.optional(), opts)
-
-  const typingsNullableOptional = toTypescript(type.nullable().optional(), opts)
-
-  const typingsOptionalNullable = toTypescript(type.optional().nullable(), opts)
-
-  const output = [baseTypings, typingsNullable, typingsOptional, typingsNullableOptional, typingsOptionalNullable]
-
-  return output
-}
-
-describe.concurrent('primitives', () => {
-  it.concurrent.each(getTypingVariations(z.string().title('MyString'), { declaration: true }))(
-    'string',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.number().title('MyNumber'), { declaration: true }))(
-    'number',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.bigint().title('MyBigInt'), { declaration: true }))(
-    'int',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.boolean().title('MyBoolean'), { declaration: true }))(
-    'boolean',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.date().title('MyDate'), { declaration: true }))(
-    'date',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.undefined().title('MyUndefined'), { declaration: true }))(
-    'undefined',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.null().title('MyNull'), { declaration: true }))('null', (typings) => {
-    expect(typings).toBeValidTypeScript()
-  })
-  it.concurrent.each(getTypingVariations(z.unknown().title('MyUnknown'), { declaration: true }))(
-    'unknown',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.never().title('MyNever'), { declaration: true }))(
-    'never',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.nan().title('MyNaNBreadMiam'), { declaration: true }))(
-    'nan',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.symbol().title('MySymbol'), { declaration: true }))(
-    'symbol',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
-  it.concurrent.each(getTypingVariations(z.literal('bob').title('MYLiteral'), { declaration: true }))(
-    'function',
-    (typings) => {
-      expect(typings).toBeValidTypeScript()
-    },
-    5000,
-  )
+test('string', async () => {
+  const schema = z.string().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: string')
+})
+test('string nullable', async () => {
+  const schema = z.string().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: string | null')
+})
+test('string optional', async () => {
+  const schema = z.string().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: string | undefined')
+})
+test('string nullable optional', async () => {
+  const schema = z.string().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: string | null | undefined')
+})
+test('string optional nullable', async () => {
+  const schema = z.string().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: string | undefined | null')
+})
+test('number', async () => {
+  const schema = z.number().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number')
+})
+test('number nullable', async () => {
+  const schema = z.number().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number | null')
+})
+test('number optional', async () => {
+  const schema = z.number().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number | undefined')
+})
+test('number nullable optional', async () => {
+  const schema = z.number().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number | null | undefined')
+})
+test('number optional nullable', async () => {
+  const schema = z.number().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number | undefined | null')
+})
+test('bigint', async () => {
+  const schema = z.bigint().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number') // should be bigint instead of number
+})
+test('bigint nullable', async () => {
+  const schema = z.bigint().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number | null') // should be bigint instead of number
+})
+test('bigint optional', async () => {
+  const schema = z.bigint().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number | undefined') // should be bigint instead of number
+})
+test('bigint nullable optional', async () => {
+  const schema = z.bigint().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number | null | undefined') // should be bigint instead of number
+})
+test('bigint optional nullable', async () => {
+  const schema = z.bigint().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: number | undefined | null') // should be bigint instead of number
+})
+test('boolean', async () => {
+  const schema = z.boolean().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: boolean')
+})
+test('boolean nullable', async () => {
+  const schema = z.boolean().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: boolean | null')
+})
+test('boolean optional', async () => {
+  const schema = z.boolean().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: boolean | undefined')
+})
+test('boolean nullable optional', async () => {
+  const schema = z.boolean().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: boolean | null | undefined')
+})
+test('boolean optional nullable', async () => {
+  const schema = z.boolean().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: boolean | undefined | null')
+})
+test('date', async () => {
+  const schema = z.date().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: Date')
+})
+test('date nullable', async () => {
+  const schema = z.date().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: Date | null')
+})
+test('date optional', async () => {
+  const schema = z.date().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: Date | undefined')
+})
+test('date nullable optional', async () => {
+  const schema = z.date().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: Date | null | undefined')
+})
+test('date optional nullable', async () => {
+  const schema = z.date().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: Date | undefined | null')
+})
+test('undefined', async () => {
+  const schema = z.undefined().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: undefined')
+})
+test('undefined nullable', async () => {
+  const schema = z.undefined().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: undefined | null')
+})
+test('undefined optional', async () => {
+  const schema = z.undefined().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: undefined | undefined')
+})
+test('undefined nullable optional', async () => {
+  const schema = z.undefined().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: undefined | null | undefined')
+})
+test('undefined optional nullable', async () => {
+  const schema = z.undefined().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: undefined | undefined | null')
+})
+test('null', async () => {
+  const schema = z.null().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: null')
+})
+test('null nullable', async () => {
+  const schema = z.null().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: null | null')
+})
+test('null optional', async () => {
+  const schema = z.null().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: null | undefined')
+})
+test('null nullable optional', async () => {
+  const schema = z.null().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: null | null | undefined')
+})
+test('null optional nullable', async () => {
+  const schema = z.null().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: null | undefined | null')
+})
+test('unknown', async () => {
+  const schema = z.unknown().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: unknown')
+})
+test('unknown nullable', async () => {
+  const schema = z.unknown().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: unknown | null')
+})
+test('unknown optional', async () => {
+  const schema = z.unknown().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: unknown | undefined')
+})
+test('unknown nullable optional', async () => {
+  const schema = z.unknown().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: unknown | null | undefined')
+})
+test('unknown optional nullable', async () => {
+  const schema = z.unknown().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: unknown | undefined | null')
+})
+test('never', async () => {
+  const schema = z.never().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: never')
+})
+test('never nullable', async () => {
+  const schema = z.never().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: never | null')
+})
+test('never optional', async () => {
+  const schema = z.never().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: never | undefined')
+})
+test('never nullable optional', async () => {
+  const schema = z.never().nullable().optional().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: never | null | undefined')
+})
+test('never optional nullable', async () => {
+  const schema = z.never().optional().nullable().title('x')
+  const typings: string = toTypescriptType(schema)
+  await expect(typings).toMatchWithoutFormatting('declare const x: never | undefined | null')
 })

--- a/zui/src/vitest.d.ts
+++ b/zui/src/vitest.d.ts
@@ -2,7 +2,6 @@ import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
 
 interface CustomMatchers<R = unknown> {
   toMatchWithoutFormatting: (expected: string) => Promise<R>
-  toBeValidTypeScript: () => R
 }
 
 declare module 'vitest' {


### PR DESCRIPTION
The custom vitest expect `toBeValidTypescript` below

```ts
expect(`const a: string = "banana"`).toBeValidTypescript()
```

was unbelievably slow. 

By migrating to proper tests with clear expected values, the test execution time goes down by a factor of more than 10x (~140s to ~10s)