### PR TITLE
fix(opapi): include HTTP 424 in ApiError.status and add type guard

### DIFF
--- a/opapi/package.json
+++ b/opapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/opapi",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/opapi/src/generators/errors.ts
+++ b/opapi/src/generators/errors.ts
@@ -18,7 +18,7 @@ const codes = {
   HTTP_STATUS_BAD_GATEWAY: 502,
   HTTP_STATUS_SERVICE_UNAVAILABLE: 503,
   HTTP_STATUS_GATEWAY_TIMEOUT: 504,
-} as const
+} as const satisfies Record<string, ApiError['status']>
 
 export function generateErrors(errors: ApiError[]) {
   const types = errors.map((error) => error.type)

--- a/opapi/src/state.ts
+++ b/opapi/src/state.ts
@@ -44,7 +44,7 @@ const internalError: ApiError = {
 }
 
 export type ApiError = {
-  status: 400 | 401 | 402 | 403 | 404 | 405 | 408 | 409 | 413 | 415 | 429 | 500 | 501 | 502 | 503 | 504
+  status: 400 | 401 | 402 | 403 | 404 | 405 | 408 | 409 | 413 | 415 | 424 | 429 | 500 | 501 | 502 | 503 | 504
   type: string
   description: string
 }


### PR DESCRIPTION
There was a separate place where the new HTTP code had to be also added. I also added a type guard to prevent this from being overlooked so easily in the future.