### PR TITLE
fix(zui): export schemas of JSONSchema

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/ui/index.ts
+++ b/zui/src/ui/index.ts
@@ -11,6 +11,8 @@ export type {
   ZuiReactComponent,
   ZuiReactComponentProps,
   JSONSchema,
+  ObjectSchema,
+  ArraySchema,
   JSONSchemaOfType,
   MergeUIComponentDefinitions,
   FormValidation,

--- a/zui/src/ui/index.ts
+++ b/zui/src/ui/index.ts
@@ -3,6 +3,8 @@ export { ZuiForm, type ZuiFormProps } from './Form'
 export * from './component-definitions'
 export * from './ErrorBoundary'
 
+export { isObjectSchema, isArraySchema } from './utils'
+
 export type {
   BaseType,
   UIComponentDefinitions,

--- a/zui/src/ui/utils.ts
+++ b/zui/src/ui/utils.ts
@@ -1,6 +1,6 @@
 import { zuiKey } from './constants'
 import { resolveDiscriminator } from './hooks/useDiscriminator'
-import { BaseType, JSONSchema, Path, ZuiComponentMap, ZuiReactComponent } from './types'
+import { ArraySchema, BaseType, JSONSchema, ObjectSchema, Path, ZuiComponentMap, ZuiReactComponent } from './types'
 
 type ComponentMeta<Type extends BaseType = BaseType> = {
   type: Type
@@ -545,3 +545,11 @@ const specialCase = [
   'XSS',
   'YouTube',
 ]
+
+export function isObjectSchema(schema: JSONSchema): schema is ObjectSchema {
+  return schema.type === 'object' && typeof schema.properties === 'object' && schema.properties !== null
+}
+
+export function isArraySchema(schema: JSONSchema): schema is ArraySchema {
+  return schema.type === 'array' && typeof schema.items === 'object' && schema.items !== null
+}


### PR DESCRIPTION
The lib only exports JSONSchema, but in 90% of our use cases, we use the ObjectSchema only. This would just expose the types that are under JSONSchema, and a small guard to simplify usage