### PR TITLE
fix(zui): fix ui test "calls onValidation w/ validation"

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/ui/ui.test.tsx
+++ b/zui/src/ui/ui.test.tsx
@@ -3,7 +3,14 @@ import { fireEvent, render } from '@testing-library/react'
 import { ZuiForm, ZuiFormProps } from './index'
 import { resolveDiscriminatedSchema, resolveDiscriminator } from './hooks/useDiscriminator'
 import { ZuiComponentMap } from '../index'
-import { ObjectSchema, JSONSchema, ZuiReactComponentBaseProps, BaseType, UIComponentDefinitions } from './types'
+import {
+  ObjectSchema,
+  JSONSchema,
+  ZuiReactComponentBaseProps,
+  BaseType,
+  UIComponentDefinitions,
+  FormValidation,
+} from './types'
 import { FC, PropsWithChildren, useState } from 'react'
 import { vi } from 'vitest'
 import { z as zui } from '../z/index'
@@ -354,7 +361,7 @@ describe('UI', () => {
       age: zui.number().min(8),
     })
 
-    const spy = vi.fn()
+    const spy = vi.fn<[validation: FormValidation], void>()
 
     const rendered = render(
       <ZuiFormWithState
@@ -368,18 +375,18 @@ describe('UI', () => {
     const ageInput = rendered.getByTestId('number:age:input') as HTMLInputElement
 
     fireEvent.change(nameInput, { target: { value: 'Joh' } })
-    expect(spy.mock.calls.every((call) => call.formValid === false)).toStrictEqual(false)
-    expect(spy.mock.lastCall[0].formErrors).toHaveLength(1)
+    expect(spy.mock.calls.every(([call]) => call?.formValid === true)).toStrictEqual(false)
+    expect(spy.mock.lastCall?.[0].formErrors).toHaveLength(1)
 
     fireEvent.change(ageInput, { target: { value: '5' } })
 
-    expect(spy.mock.calls.every((call) => call.formValid === false)).toStrictEqual(false)
-    expect(spy.mock.lastCall[0].formErrors).toHaveLength(1)
+    expect(spy.mock.calls.every(([call]) => call?.formValid === true)).toStrictEqual(false)
+    expect(spy.mock.lastCall?.[0].formErrors).toHaveLength(1)
 
     fireEvent.change(ageInput, { target: { value: '10' } })
 
-    expect(spy.mock.lastCall[0].formValid).toStrictEqual(true)
-    expect(spy.mock.lastCall[0].formErrors).toHaveLength(0)
+    expect(spy.mock.lastCall?.[0].formValid).toStrictEqual(true)
+    expect(spy.mock.lastCall?.[0].formErrors).toHaveLength(0)
   })
 
   it('returns null formValidation when disableValidation is true', () => {
@@ -388,7 +395,7 @@ describe('UI', () => {
       age: zui.number().min(8),
     })
 
-    const spy = vi.fn()
+    const spy = vi.fn<[validation: FormValidation], void>()
 
     const rendered = render(
       <ZuiFormWithState


### PR DESCRIPTION
In vitest 1.x, the `callls` member of the `MockContext` interface is defined as `TArgs[]`, with `TArgs` being provided by `const mock = vi.fn<TArgs, TRet>()`. However, if we do not provide type parameters to `vi.fn`, `TArgs` will default to `any`, which means we'd have `interface MockContext { calls: any[] }`, but the actual real type is `any[][]`, since `calls` is an array of arrays of invocation parameters.

In vitest 2.x, the signature of `vi.fn` was changed to `vi.fn<TFunc = any>` and `MockContext` was updated to `interface MockContext { calls: Parameters<TFunc> }`. This means that even if we omit providing a type to `vi.fn()`, `calls` will properly have the type `any[][]` instead of the `any[]` from vitest 1.x.

This means that in vitest 1.x, if you were to do something like `const spy = vi.fn()` and call it with `spy({ fooBar: true })`, `spy.mock.calls.map((call) => call.fooBar)` would equal `[ undefined ]` because `call` is an array. But you wouldn't know this because the type is evaluated to `any` instead of `any[]`.