### PR TITLE
chore(zui): remove a bunch of as any statements

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/transforms/json-schema-to-zui/parsers/parseAllOf.ts
+++ b/zui/src/transforms/json-schema-to-zui/parsers/parseAllOf.ts
@@ -32,7 +32,7 @@ export function parseAllOf(schema: JsonSchemaObject & { allOf: JsonSchema[] }, r
       path: [...refs.path, 'allOf', (item as any)[originalIndex]],
     })
   } else {
-    const [left, right] = half(ensureOriginalIndex(schema.allOf)) as any
+    const [left, right] = half(ensureOriginalIndex(schema.allOf))
 
     return `z.intersection(${parseAllOf({ allOf: left }, refs)}, ${parseAllOf(
       {

--- a/zui/src/transforms/json-schema-to-zui/parsers/parseMultipleType.ts
+++ b/zui/src/transforms/json-schema-to-zui/parsers/parseMultipleType.ts
@@ -2,5 +2,5 @@ import { JsonSchemaObject, Refs } from '../types'
 import { parseSchema } from './parseSchema'
 
 export const parseMultipleType = (schema: JsonSchemaObject & { type: string[] }, refs: Refs) => {
-  return `z.union([${schema.type.map((type) => parseSchema({ ...schema, type } as any, refs)).join(', ')}])`
+  return `z.union([${schema.type.map((type) => parseSchema({ ...schema, type }, refs)).join(', ')}])`
 }

--- a/zui/src/transforms/json-schema-to-zui/parsers/parseObject.ts
+++ b/zui/src/transforms/json-schema-to-zui/parsers/parseObject.ts
@@ -167,7 +167,7 @@ export function parseObject(objectSchema: JsonSchemaObject & { type: 'object' } 
           typeof x === 'object' && !x.type && (x.properties || x.additionalProperties || x.patternProperties)
             ? { ...x, type: 'object' }
             : x,
-        ) as any,
+        ),
       },
       refs,
     )})`
@@ -181,7 +181,7 @@ export function parseObject(objectSchema: JsonSchemaObject & { type: 'object' } 
           typeof x === 'object' && !x.type && (x.properties || x.additionalProperties || x.patternProperties)
             ? { ...x, type: 'object' }
             : x,
-        ) as any,
+        ),
       },
       refs,
     )})`
@@ -195,7 +195,7 @@ export function parseObject(objectSchema: JsonSchemaObject & { type: 'object' } 
           typeof x === 'object' && !x.type && (x.properties || x.additionalProperties || x.patternProperties)
             ? { ...x, type: 'object' }
             : x,
-        ) as any,
+        ),
       },
       refs,
     )})`

--- a/zui/src/transforms/json-schema-to-zui/parsers/parseSchema.ts
+++ b/zui/src/transforms/json-schema-to-zui/parsers/parseSchema.ts
@@ -142,7 +142,7 @@ export const its = {
     } => x.enum !== undefined,
   },
   a: {
-    nullable: (x: JsonSchemaObject): x is JsonSchemaObject & { nullable: true } => (x as any).nullable === true,
+    nullable: (x: JsonSchemaObject): x is JsonSchemaObject & { nullable: true } => x.nullable === true,
     multipleType: (x: JsonSchemaObject): x is JsonSchemaObject & { type: string[] } => Array.isArray(x.type),
     not: (
       x: JsonSchemaObject,

--- a/zui/src/transforms/json-schema-to-zui/utils.ts
+++ b/zui/src/transforms/json-schema-to-zui/utils.ts
@@ -11,7 +11,7 @@ export const omit = <T extends object, K extends keyof T>(obj: T, ...keys: K[]):
     }
 
     return acc
-  }, {}) as any
+  }, {}) as Omit<T, K>
 
 type Opener = string
 type MessagePrefix = string

--- a/zui/src/ui/ElementRenderer.tsx
+++ b/zui/src/ui/ElementRenderer.tsx
@@ -73,7 +73,7 @@ export const FormElementRenderer: FC<FormRendererProps> = ({
   }
 
   if (fieldSchema.type === 'array' && type === 'array') {
-    const Component = _component as any as ZuiReactComponent<'array', string, any>
+    const Component = _component as ZuiReactComponent<'array', string, any>
     const schema = baseProps.schema as ArraySchema
     const dataArray = Array.isArray(data) ? data : typeof data === 'object' ? data : []
     const props: Omit<ZuiReactComponentProps<'array', string, any>, 'children'> = {
@@ -196,8 +196,8 @@ export const FormElementRenderer: FC<FormRendererProps> = ({
 
   const props: ZuiReactControlComponentProps<'boolean' | 'number' | 'string', string, any> = {
     ...baseProps,
-    type: type as any as 'boolean' | 'number' | 'string',
-    schema: baseProps.schema as any as PrimitiveSchema,
+    type: type as 'boolean' | 'number' | 'string',
+    schema: baseProps.schema as PrimitiveSchema,
     config: {},
     required,
     data,

--- a/zui/src/z/__tests__/set.test.ts
+++ b/zui/src/z/__tests__/set.test.ts
@@ -126,7 +126,7 @@ test('throws when the given set has invalid input', () => {
 })
 
 test('throws when the given set has multiple invalid entries', () => {
-  const result = stringSet.safeParse(new Set([1, 2] as any[]) as Set<any>)
+  const result = stringSet.safeParse(new Set([1, 2]) as Set<any>)
 
   expect(result.success).toEqual(false)
   if (result.success === false) {

--- a/zui/src/z/benchmarks/discriminatedUnion.ts
+++ b/zui/src/z/benchmarks/discriminatedUnion.ts
@@ -51,7 +51,7 @@ doubleSuite
     } catch (err) {}
   })
   .on('cycle', (e: Benchmark.Event) => {
-    console.log(`${(doubleSuite as any).name}: ${e.target}`)
+    console.log(`${doubleSuite.name}: ${e.target}`)
   })
 
 manySuite
@@ -72,7 +72,7 @@ manySuite
     } catch (err) {}
   })
   .on('cycle', (e: Benchmark.Event) => {
-    console.log(`${(manySuite as any).name}: ${e.target}`)
+    console.log(`${manySuite.name}: ${e.target}`)
   })
 
 export default {

--- a/zui/src/z/benchmarks/object.ts
+++ b/zui/src/z/benchmarks/object.ts
@@ -29,7 +29,7 @@ emptySuite
     } catch (err) {}
   })
   .on('cycle', (e: Benchmark.Event) => {
-    console.log(`${(emptySuite as any).name}: ${e.target}`)
+    console.log(`${emptySuite.name}: ${e.target}`)
   })
 
 shortSuite
@@ -45,7 +45,7 @@ shortSuite
     } catch (err) {}
   })
   .on('cycle', (e: Benchmark.Event) => {
-    console.log(`${(shortSuite as any).name}: ${e.target}`)
+    console.log(`${shortSuite.name}: ${e.target}`)
   })
 
 longSuite
@@ -61,7 +61,7 @@ longSuite
     } catch (err) {}
   })
   .on('cycle', (e: Benchmark.Event) => {
-    console.log(`${(longSuite as any).name}: ${e.target}`)
+    console.log(`${longSuite.name}: ${e.target}`)
   })
 
 export default {

--- a/zui/src/z/benchmarks/realworld.ts
+++ b/zui/src/z/benchmarks/realworld.ts
@@ -55,7 +55,7 @@ shortSuite
     People.parse(people)
   })
   .on('cycle', (e: Benchmark.Event) => {
-    console.log(`${(shortSuite as any).name}: ${e.target}`)
+    console.log(`${shortSuite.name}: ${e.target}`)
   })
 
 export default {

--- a/zui/src/z/benchmarks/union.ts
+++ b/zui/src/z/benchmarks/union.ts
@@ -51,7 +51,7 @@ doubleSuite
     } catch (err) {}
   })
   .on('cycle', (e: Benchmark.Event) => {
-    console.log(`${(doubleSuite as any).name}: ${e.target}`)
+    console.log(`${doubleSuite.name}: ${e.target}`)
   })
 
 manySuite
@@ -72,7 +72,7 @@ manySuite
     } catch (err) {}
   })
   .on('cycle', (e: Benchmark.Event) => {
-    console.log(`${(manySuite as any).name}: ${e.target}`)
+    console.log(`${manySuite.name}: ${e.target}`)
   })
 
 export default {

--- a/zui/src/z/types/array/index.ts
+++ b/zui/src/z/types/array/index.ts
@@ -121,7 +121,7 @@ export class ZodArray<T extends ZodTypeAny = ZodTypeAny, Cardinality extends Arr
 
     if (ctx.common.async) {
       return Promise.all(
-        ([...ctx.data] as any[]).map((item, i) => {
+        [...ctx.data].map((item, i) => {
           return def.type._parseAsync(new ParseInputLazyPath(ctx, item, ctx.path, i))
         }),
       ).then((result) => {
@@ -129,7 +129,7 @@ export class ZodArray<T extends ZodTypeAny = ZodTypeAny, Cardinality extends Arr
       })
     }
 
-    const result = ([...ctx.data] as any[]).map((item, i) => {
+    const result = [...ctx.data].map((item, i) => {
       return def.type._parseSync(new ParseInputLazyPath(ctx, item, ctx.path, i))
     })
 
@@ -144,25 +144,25 @@ export class ZodArray<T extends ZodTypeAny = ZodTypeAny, Cardinality extends Arr
     return new ZodArray({
       ...this._def,
       minLength: { value: minLength, message: errorUtil.toString(message) },
-    }) as any
+    }) as this
   }
 
   max(maxLength: number, message?: errorUtil.ErrMessage): this {
     return new ZodArray({
       ...this._def,
       maxLength: { value: maxLength, message: errorUtil.toString(message) },
-    }) as any
+    }) as this
   }
 
   length(len: number, message?: errorUtil.ErrMessage): this {
     return new ZodArray({
       ...this._def,
       exactLength: { value: len, message: errorUtil.toString(message) },
-    }) as any
+    }) as this
   }
 
   nonempty(message?: errorUtil.ErrMessage): ZodArray<T, 'atleastone'> {
-    return this.min(1, message) as any
+    return this.min(1, message) as ZodArray<T, 'atleastone'>
   }
 
   static create = <T extends ZodTypeAny>(schema: T, params?: RawCreateParams): ZodArray<T> => {

--- a/zui/src/z/types/basetype/index.ts
+++ b/zui/src/z/types/basetype/index.ts
@@ -391,10 +391,10 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
   }
 
   optional(): ZodOptional<this> {
-    return ZodOptional.create(this, this._def) as any
+    return ZodOptional.create(this, this._def)
   }
   nullable(): ZodNullable<this> {
-    return ZodNullable.create(this, this._def) as any
+    return ZodNullable.create(this, this._def)
   }
   nullish(): ZodOptional<ZodNullable<this>> {
     return this.nullable().optional()
@@ -407,7 +407,7 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
   }
 
   or<T extends ZodTypeAny>(option: T): ZodUnion<[this, T]> {
-    return ZodUnion.create([this, option], this._def) as any
+    return ZodUnion.create([this, option], this._def)
   }
 
   and<T extends ZodTypeAny>(incoming: T): ZodIntersection<this, T> {
@@ -422,7 +422,7 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
       schema: this,
       typeName: ZodFirstPartyTypeKind.ZodEffects,
       effect: { type: 'transform', transform },
-    }) as any
+    })
   }
 
   default(def: util.noUndefined<Input>): ZodDefault<this>

--- a/zui/src/z/types/default/index.ts
+++ b/zui/src/z/types/default/index.ts
@@ -56,9 +56,9 @@ export class ZodDefault<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return new ZodDefault({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodDefault,
-      defaultValue: typeof value === 'function' ? value : () => value as any,
+      defaultValue: typeof value === 'function' ? value : () => value,
       ...processCreateParams(params),
-    }) as any
+    })
   }
 
   isEqual(schema: ZodType): boolean {

--- a/zui/src/z/types/discriminatedUnion/index.ts
+++ b/zui/src/z/types/discriminatedUnion/index.ts
@@ -46,7 +46,7 @@ const getDiscriminator = <T extends ZodTypeAny>(type: T): Primitive[] => {
     return type.options
   } else if (type instanceof ZodNativeEnum) {
     // eslint-disable-next-line ban/ban
-    return util.objectValues(type.enum as any)
+    return util.objectValues(type.enum)
   } else if (type instanceof ZodDefault) {
     return getDiscriminator(type._def.innerType)
   } else if (type instanceof ZodUndefined) {
@@ -141,13 +141,13 @@ export class ZodDiscriminatedUnion<
         data: ctx.data,
         path: ctx.path,
         parent: ctx,
-      }) as any
+      }) as ParseReturnType<this['_output']>
     } else {
       return option._parseSync({
         data: ctx.data,
         path: ctx.path,
         parent: ctx,
-      }) as any
+      }) as ParseReturnType<this['_output']>
     }
   }
 

--- a/zui/src/z/types/enum/index.ts
+++ b/zui/src/z/types/enum/index.ts
@@ -94,7 +94,7 @@ export class ZodEnum<T extends [string, ...string[]] = [string, ...string[]]> ex
     for (const val of this._def.values) {
       enumValues[val] = val
     }
-    return enumValues as any
+    return enumValues
   }
 
   get Values(): Values<T> {
@@ -102,7 +102,7 @@ export class ZodEnum<T extends [string, ...string[]] = [string, ...string[]]> ex
     for (const val of this._def.values) {
       enumValues[val] = val
     }
-    return enumValues as any
+    return enumValues
   }
 
   get Enum(): Values<T> {
@@ -110,7 +110,7 @@ export class ZodEnum<T extends [string, ...string[]] = [string, ...string[]]> ex
     for (const val of this._def.values) {
       enumValues[val] = val
     }
-    return enumValues as any
+    return enumValues
   }
 
   extract<ToExtract extends readonly [T[number], ...T[number][]]>(
@@ -120,7 +120,7 @@ export class ZodEnum<T extends [string, ...string[]] = [string, ...string[]]> ex
     return ZodEnum.create(values, {
       ...this._def,
       ...newDef,
-    }) as any
+    })
   }
 
   exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
@@ -130,7 +130,7 @@ export class ZodEnum<T extends [string, ...string[]] = [string, ...string[]]> ex
     return ZodEnum.create(this.options.filter((opt) => !values.includes(opt)) as FilterEnum<T, ToExclude[number]>, {
       ...this._def,
       ...newDef,
-    }) as any
+    }) as ZodEnum<typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>>
   }
 
   static create = createZodEnum

--- a/zui/src/z/types/error/error.test.ts
+++ b/zui/src/z/types/error/error.test.ts
@@ -39,7 +39,7 @@ test('type error with custom error map', () => {
   try {
     z.string().parse(234, { errorMap })
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
 
     expect(zerr.issues[0]?.code).toEqual(z.ZodIssueCode.invalid_type)
     expect(zerr.issues[0]?.message).toEqual(`bad type!`)
@@ -54,7 +54,7 @@ test('refinement fail with params', () => {
       })
       .parse(2, { errorMap })
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues[0]?.code).toEqual(z.ZodIssueCode.custom)
     expect(zerr.issues[0]?.message).toEqual(`less-than-3`)
   }
@@ -69,7 +69,7 @@ test('custom error with custom errormap', () => {
       })
       .parse('asdf', { errorMap })
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues[0]?.message).toEqual('override')
   }
 })
@@ -80,7 +80,7 @@ test('default error message', () => {
       .refine((x) => x > 3)
       .parse(2)
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues.length).toEqual(1)
     expect(zerr.issues[0]?.message).toEqual('Invalid input')
   }
@@ -92,7 +92,7 @@ test('override error in refine', () => {
       .refine((x) => x > 3, 'override')
       .parse(2)
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues.length).toEqual(1)
     expect(zerr.issues[0]?.message).toEqual('override')
   }
@@ -106,7 +106,7 @@ test('override error in refinement', () => {
       })
       .parse(2)
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues.length).toEqual(1)
     expect(zerr.issues[0]?.message).toEqual('override')
   }
@@ -116,14 +116,14 @@ test('array minimum', () => {
   try {
     z.array(z.string()).min(3, 'tooshort').parse(['asdf', 'qwer'])
   } catch (err) {
-    const zerr: ZodError = err as any
+    const zerr = err as ZodError
     expect(zerr.issues[0]?.code).toEqual(ZodIssueCode.too_small)
     expect(zerr.issues[0]?.message).toEqual('tooshort')
   }
   try {
     z.array(z.string()).min(3).parse(['asdf', 'qwer'])
   } catch (err) {
-    const zerr: ZodError = err as any
+    const zerr = err as ZodError
     expect(zerr.issues[0]?.code).toEqual(ZodIssueCode.too_small)
     expect(zerr.issues[0]?.message).toEqual(`Array must contain at least 3 element(s)`)
   }
@@ -445,7 +445,7 @@ test('enum error message, invalid enum elementstring', () => {
   try {
     z.enum(['Tuna', 'Trout']).parse('Salmon')
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues.length).toEqual(1)
     expect(zerr.issues[0]?.message).toEqual("Invalid enum value. Expected 'Tuna' | 'Trout', received 'Salmon'")
   }
@@ -455,7 +455,7 @@ test('enum error message, invalid type', () => {
   try {
     z.enum(['Tuna', 'Trout']).parse(12)
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues.length).toEqual(1)
     expect(zerr.issues[0]?.message).toEqual("Expected 'Tuna' | 'Trout', received number")
   }
@@ -469,7 +469,7 @@ test('nativeEnum default error message', () => {
   try {
     z.nativeEnum(Fish).parse('Salmon')
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues.length).toEqual(1)
     expect(zerr.issues[0]?.message).toEqual("Invalid enum value. Expected 'Tuna' | 'Trout', received 'Salmon'")
   }
@@ -479,7 +479,7 @@ test('literal default error message', () => {
   try {
     z.literal('Tuna').parse('Trout')
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues.length).toEqual(1)
     expect(zerr.issues[0]?.message).toEqual(`Invalid literal value, expected "Tuna"`)
   }
@@ -489,7 +489,7 @@ test('literal bigint default error message', () => {
   try {
     z.literal(BigInt(12)).parse(BigInt(13))
   } catch (err) {
-    const zerr: z.ZodError = err as any
+    const zerr = err as z.ZodError
     expect(zerr.issues.length).toEqual(1)
     expect(zerr.issues[0]?.message).toEqual(`Invalid literal value, expected "12"`)
   }

--- a/zui/src/z/types/error/index.ts
+++ b/zui/src/z/types/error/index.ts
@@ -217,7 +217,7 @@ export class ZodError<T = any> extends Error {
       function (issue: ZodIssue) {
         return issue.message
       }
-    const fieldErrors: ZodFormattedError<T> = { _errors: [] } as any
+    const fieldErrors = { _errors: [] } as ZodFormattedError<T>
     const processError = (error: ZodError) => {
       for (const issue of error.issues) {
         if (issue.code === 'invalid_union') {
@@ -227,7 +227,7 @@ export class ZodError<T = any> extends Error {
         } else if (issue.code === 'invalid_arguments') {
           processError(issue.argumentsError)
         } else if (issue.path.length === 0) {
-          ;(fieldErrors as any)._errors.push(mapper(issue))
+          fieldErrors._errors.push(mapper(issue))
         } else {
           let curr: any = fieldErrors
           let i = 0
@@ -292,7 +292,7 @@ export class ZodError<T = any> extends Error {
 
   flatten(): typeToFlattenedError<T>
   flatten<U>(mapper?: (issue: ZodIssue) => U): typeToFlattenedError<T, U>
-  flatten<U = string>(mapper: (issue: ZodIssue) => U = (issue: ZodIssue) => issue.message as any): any {
+  flatten<U = string>(mapper: (issue: ZodIssue) => U = (issue: ZodIssue) => issue.message as U): any {
     const fieldErrors: any = {}
     const formErrors: U[] = []
     for (const sub of this.issues) {

--- a/zui/src/z/types/function/index.ts
+++ b/zui/src/z/types/function/index.ts
@@ -113,7 +113,7 @@ export class ZodFunction<
           error.addIssue(makeArgsIssue(args, e))
           throw error
         })
-        const result = await Reflect.apply(fn, this, parsedArgs as any)
+        const result = await Reflect.apply(fn, this, parsedArgs)
         const parsedReturns = await (me._def.returns as unknown as ZodPromise<ZodTypeAny>)._def.type
           .parseAsync(result, params)
           .catch((e) => {
@@ -138,7 +138,7 @@ export class ZodFunction<
           throw new ZodError([makeReturnsIssue(result, parsedReturns.error)])
         }
         return parsedReturns.data
-      }) as any
+      })
     }
   }
 
@@ -155,7 +155,7 @@ export class ZodFunction<
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
       ...this._def,
-      args: ZodTuple.create(items).rest(ZodUnknown.create()) as any,
+      args: ZodTuple.create(items).rest(ZodUnknown.create()),
     })
   }
 
@@ -172,12 +172,12 @@ export class ZodFunction<
     ? (...args: Args['_input']) => ReturnType<F>
     : OuterTypeOfFunction<Args, Returns> {
     const validatedFunc = this.parse(func)
-    return validatedFunc as any
+    return validatedFunc
   }
 
   strictImplement(func: InnerTypeOfFunction<Args, Returns>): InnerTypeOfFunction<Args, Returns> {
     const validatedFunc = this.parse(func)
-    return validatedFunc as any
+    return validatedFunc
   }
 
   validate = this.implement
@@ -192,11 +192,11 @@ export class ZodFunction<
   ): ZodFunction<T, U>
   static create(args?: AnyZodTuple, returns?: ZodTypeAny, params?: RawCreateParams) {
     return new ZodFunction({
-      args: (args ? args : ZodTuple.create([]).rest(ZodUnknown.create())) as any,
+      args: args ? args : ZodTuple.create([]).rest(ZodUnknown.create()),
       returns: returns || ZodUnknown.create(),
       typeName: ZodFirstPartyTypeKind.ZodFunction,
       ...processCreateParams(params),
-    }) as any
+    })
   }
 
   isEqual(schema: ZodType): boolean {

--- a/zui/src/z/types/intersection/index.ts
+++ b/zui/src/z/types/intersection/index.ts
@@ -113,7 +113,7 @@ export class ZodIntersection<T extends ZodTypeAny = ZodTypeAny, U extends ZodTyp
         status.dirty()
       }
 
-      return { status: status.value, value: merged.data as any }
+      return { status: status.value, value: merged.data }
     }
 
     if (ctx.common.async) {

--- a/zui/src/z/types/nativeEnum/index.ts
+++ b/zui/src/z/types/nativeEnum/index.ts
@@ -48,7 +48,7 @@ export class ZodNativeEnum<T extends EnumLike = EnumLike> extends ZodType<T[keyo
       })
       return INVALID
     }
-    return OK(input.data as any)
+    return OK(input.data)
   }
 
   get enum() {

--- a/zui/src/z/types/nativeEnum/nativeEnum.test.ts
+++ b/zui/src/z/types/nativeEnum/nativeEnum.test.ts
@@ -52,7 +52,7 @@ test('from enum', () => {
     Banana = 'banana',
   }
 
-  const FruitEnum = z.nativeEnum(Fruits as any)
+  const FruitEnum = z.nativeEnum(Fruits)
   type FruitEnum = z.infer<typeof FruitEnum>
   FruitEnum.parse(Fruits.Cantaloupe)
   FruitEnum.parse(Fruits.Apple)

--- a/zui/src/z/types/nullable/index.ts
+++ b/zui/src/z/types/nullable/index.ts
@@ -51,7 +51,7 @@ export class ZodNullable<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodNullable,
       ...processCreateParams(params),
-    }) as any
+    })
   }
 
   isEqual(schema: ZodType): boolean {

--- a/zui/src/z/types/object/index.ts
+++ b/zui/src/z/types/object/index.ts
@@ -93,7 +93,7 @@ function deepPartialify(schema: ZodTypeAny): any {
     return new ZodObject({
       ...schema._def,
       shape: () => newShape,
-    }) as any
+    })
   } else if (schema instanceof ZodArray) {
     return new ZodArray({
       ...schema._def,
@@ -270,21 +270,21 @@ export class ZodObject<
             },
           }
         : {}),
-    }) as any
+    })
   }
 
   strip(): ZodObject<T, 'strip', Catchall> {
     return new ZodObject({
       ...this._def,
       unknownKeys: 'strip',
-    }) as any
+    })
   }
 
   passthrough(): ZodObject<T, 'passthrough', Catchall> {
     return new ZodObject({
       ...this._def,
       unknownKeys: 'passthrough',
-    }) as any
+    })
   }
 
   /**
@@ -308,7 +308,7 @@ export class ZodObject<
   //         ...def.shape(),
   //         ...augmentation,
   //       }),
-  //     }) as any;
+  //     })
   //   };
   extend<Augmentation extends ZodRawShape>(
     augmentation: Augmentation,
@@ -319,7 +319,7 @@ export class ZodObject<
         ...this._def.shape(),
         ...augmentation,
       }),
-    }) as any
+    })
   }
   // extend<
   //   Augmentation extends ZodRawShape,
@@ -352,7 +352,7 @@ export class ZodObject<
   //       ...this._def.shape(),
   //       ...augmentation,
   //     }),
-  //   }) as any;
+  //   })
   // }
   /**
    * @deprecated Use `.extend` instead
@@ -375,7 +375,7 @@ export class ZodObject<
         ...merging._def.shape(),
       }),
       typeName: ZodFirstPartyTypeKind.ZodObject,
-    }) as any
+    })
     return merged
   }
   // merge<
@@ -410,7 +410,7 @@ export class ZodObject<
   //     shape: () =>
   //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
   //     typeName: ZodFirstPartyTypeKind.ZodObject,
-  //   }) as any;
+  //   });
   //   return merged;
   // }
   setKey<Key extends string, Schema extends ZodTypeAny>(
@@ -423,7 +423,13 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   > {
-    return this.augment({ [key]: schema }) as any
+    return this.augment({ [key]: schema }) as ZodObject<
+      T & {
+        [k in Key]: Schema
+      },
+      UnknownKeys,
+      Catchall
+    >
   }
   // merge<Incoming extends AnyZodObject>(
   //   merging: Incoming
@@ -443,14 +449,14 @@ export class ZodObject<
   //     shape: () =>
   //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
   //     typeName: ZodFirstPartyTypeKind.ZodObject,
-  //   }) as any;
+  //   });
   //   return merged;
   // }
   catchall<Index extends ZodTypeAny>(index: Index): ZodObject<T, UnknownKeys, Index> {
     return new ZodObject({
       ...this._def,
       catchall: index,
-    }) as any
+    })
   }
 
   pick<
@@ -469,7 +475,7 @@ export class ZodObject<
     return new ZodObject({
       ...this._def,
       shape: () => shape,
-    }) as any
+    })
   }
 
   omit<
@@ -488,14 +494,14 @@ export class ZodObject<
     return new ZodObject({
       ...this._def,
       shape: () => shape,
-    }) as any
+    })
   }
 
   /**
    * @deprecated
    */
   deepPartial(): partialUtil.DeepPartial<this> {
-    return deepPartialify(this) as any
+    return deepPartialify(this)
   }
 
   partial(): ZodObject<
@@ -534,7 +540,7 @@ export class ZodObject<
     return new ZodObject({
       ...this._def,
       shape: () => newShape,
-    }) as any
+    })
   }
 
   required(): ZodObject<
@@ -578,7 +584,7 @@ export class ZodObject<
     return new ZodObject({
       ...this._def,
       shape: () => newShape,
-    }) as any
+    })
   }
 
   keyof(): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
@@ -608,7 +614,7 @@ export class ZodObject<
       catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
-    }) as any
+    })
   }
 
   static strictCreate = <T extends ZodRawShape>(shape: T, params?: RawCreateParams): ZodObject<T, 'strict'> => {
@@ -618,7 +624,7 @@ export class ZodObject<
       catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
-    }) as any
+    })
   }
 
   static lazycreate = <T extends ZodRawShape>(shape: () => T, params?: RawCreateParams): ZodObject<T, 'strip'> => {
@@ -628,7 +634,7 @@ export class ZodObject<
       catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
-    }) as any
+    })
   }
 }
 

--- a/zui/src/z/types/optional/index.ts
+++ b/zui/src/z/types/optional/index.ts
@@ -51,7 +51,7 @@ export class ZodOptional<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodOptional,
       ...processCreateParams(params),
-    }) as any
+    })
   }
 
   isEqual(schema: ZodType): boolean {

--- a/zui/src/z/types/readonly/index.ts
+++ b/zui/src/z/types/readonly/index.ts
@@ -66,7 +66,7 @@ export class ZodReadonly<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodReadonly,
       ...processCreateParams(params),
-    }) as any
+    })
   }
 
   unwrap() {

--- a/zui/src/z/types/set/index.ts
+++ b/zui/src/z/types/set/index.ts
@@ -107,22 +107,22 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return new ZodSet({
       ...this._def,
       minSize: { value: minSize, message: errorUtil.toString(message) },
-    }) as any
+    }) as this
   }
 
   max(maxSize: number, message?: errorUtil.ErrMessage): this {
     return new ZodSet({
       ...this._def,
       maxSize: { value: maxSize, message: errorUtil.toString(message) },
-    }) as any
+    }) as this
   }
 
   size(size: number, message?: errorUtil.ErrMessage): this {
-    return this.min(size, message).max(size, message) as any
+    return this.min(size, message).max(size, message) as this
   }
 
   nonempty(message?: errorUtil.ErrMessage): ZodSet<Value> {
-    return this.min(1, message) as any
+    return this.min(1, message) as this
   }
 
   static create = <Value extends ZodTypeAny = ZodTypeAny>(

--- a/zui/src/z/types/tuple/index.ts
+++ b/zui/src/z/types/tuple/index.ts
@@ -101,10 +101,10 @@ export class ZodTuple<
       status.dirty()
     }
 
-    const items = ([...ctx.data] as any[])
+    const items = [...ctx.data]
       .map((item, itemIndex) => {
         const schema = this._def.items[itemIndex] || this._def.rest
-        if (!schema) return null as any as SyncParseReturnType<any>
+        if (!schema) return null
         return schema._parse(new ParseInputLazyPath(ctx, item, ctx.path, itemIndex))
       })
       .filter((x) => !!x) // filter nulls

--- a/zui/src/z/types/utils/index.ts
+++ b/zui/src/z/types/utils/index.ts
@@ -20,11 +20,11 @@ export namespace util {
   }
 
   export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(items: U): { [k in U[number]]: k } => {
-    const obj: any = {}
+    const obj: { [k in U[number]]?: k } = {}
     for (const item of items) {
       obj[item] = item
     }
-    return obj as any
+    return obj as { [k in U[number]]: k }
   }
 
   export const getValidEnumValues = (obj: any) => {

--- a/zui/src/z/types/utils/parseUtil.ts
+++ b/zui/src/z/types/utils/parseUtil.ts
@@ -156,8 +156,9 @@ export type SyncParseReturnType<T = any> = OK<T> | DIRTY<T> | INVALID
 export type AsyncParseReturnType<T> = Promise<SyncParseReturnType<T>>
 export type ParseReturnType<T> = SyncParseReturnType<T> | AsyncParseReturnType<T>
 
-export const isAborted = (x: ParseReturnType<any>): x is INVALID => (x as any).status === 'aborted'
-export const isDirty = <T>(x: ParseReturnType<T>): x is OK<T> | DIRTY<T> => (x as any).status === 'dirty'
-export const isValid = <T>(x: ParseReturnType<T>): x is OK<T> => (x as any).status === 'valid'
+export const isAborted = (x: ParseReturnType<any>): x is INVALID => (x as SyncParseReturnType).status === 'aborted'
+export const isDirty = <T>(x: ParseReturnType<T>): x is OK<T> | DIRTY<T> =>
+  (x as SyncParseReturnType).status === 'dirty'
+export const isValid = <T>(x: ParseReturnType<T>): x is OK<T> => (x as SyncParseReturnType).status === 'valid'
 export const isAsync = <T>(x: ParseReturnType<T>): x is AsyncParseReturnType<T> =>
   typeof Promise !== 'undefined' && x instanceof Promise


### PR DESCRIPTION
Usage of `any` is acceptable in such projects, but it still should be the last resort.

There's still of lot of work to do, to remove unsafe code, but this is progress