### PR TITLE
fix(zui): fix comments, extensions in toTypescriptSchema

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/transforms/zui-to-typescript-schema/index.ts
+++ b/zui/src/transforms/zui-to-typescript-schema/index.ts
@@ -3,7 +3,6 @@ import { mapValues } from 'lodash-es'
 import z, { util } from '../../z'
 import {
   primitiveToTypescriptValue,
-  getMultilineComment,
   unknownToTypescriptValue,
   recordOfUnknownToTypescriptRecord,
 } from '../common/utils'
@@ -28,43 +27,43 @@ function sUnwrapZod(schema: z.Schema): string {
 
   switch (def.typeName) {
     case z.ZodFirstPartyTypeKind.ZodString:
-      return `${getMultilineComment(def.description)}z.string()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.string()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNumber:
-      return `${getMultilineComment(def.description)}z.number()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.number()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNaN:
-      return `${getMultilineComment(def.description)}z.nan()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.nan()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodBigInt:
-      return `${getMultilineComment(def.description)}z.bigint()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.bigint()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodBoolean:
-      return `${getMultilineComment(schema._def.description)}z.boolean()${_addZuiExtensions(def)}${_maybeDescribe(schema._def)}`.trim()
+      return `z.boolean()${_addZuiExtensions(def)}${_maybeDescribe(schema._def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodDate:
-      return `${getMultilineComment(def.description)}z.date()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.date()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodUndefined:
-      return `${getMultilineComment(def.description)}z.undefined()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.undefined()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNull:
-      return `${getMultilineComment(def.description)}z.null()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.null()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodAny:
-      return `${getMultilineComment(def.description)}z.any()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.any()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodUnknown:
-      return `${getMultilineComment(def.description)}z.unknown()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.unknown()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNever:
-      return `${getMultilineComment(def.description)}z.never()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.never()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodVoid:
-      return `${getMultilineComment(def.description)}z.void()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.void()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodArray:
-      return `z.array(${sUnwrapZod(def.type)})`
+      return `z.array(${sUnwrapZod(def.type)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`
 
     case z.ZodFirstPartyTypeKind.ZodObject:
       const props = mapValues(def.shape(), (value) => {
@@ -75,7 +74,7 @@ function sUnwrapZod(schema: z.Schema): string {
       })
       return [
         //
-        `${getMultilineComment(def.description)}z.object({`,
+        `z.object({`,
         ...Object.entries(props).map(([key, value]) => `  ${key}: ${value},`),
         `})${_addZuiExtensions(def)}${_maybeDescribe(def)}`,
       ]
@@ -84,51 +83,51 @@ function sUnwrapZod(schema: z.Schema): string {
 
     case z.ZodFirstPartyTypeKind.ZodUnion:
       const options = def.options.map(sUnwrapZod)
-      return `${getMultilineComment(def.description)}z.union([${options.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.union([${options.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
       const opts = (def.options as z.ZodSchema[]).map(sUnwrapZod)
       const discriminator = primitiveToTypescriptValue(def.discriminator)
-      return `${getMultilineComment(def.description)}z.discriminatedUnion(${discriminator}, [${opts.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.discriminatedUnion(${discriminator}, [${opts.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodIntersection:
       const left: string = sUnwrapZod(def.left)
       const right: string = sUnwrapZod(def.right)
-      return `${getMultilineComment(def.description)}z.intersection(${left}, ${right})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.intersection(${left}, ${right})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodTuple:
       const items = def.items.map(sUnwrapZod)
-      return `${getMultilineComment(def.description)}z.tuple([${items.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.tuple([${items.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodRecord:
       const keyType = sUnwrapZod(def.keyType)
       const valueType = sUnwrapZod(def.valueType)
-      return `${getMultilineComment(def.description)}z.record(${keyType}, ${valueType})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.record(${keyType}, ${valueType})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodMap:
       const mapKeyType = sUnwrapZod(def.keyType)
       const mapValueType = sUnwrapZod(def.valueType)
-      return `${getMultilineComment(def.description)}z.map(${mapKeyType}, ${mapValueType})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.map(${mapKeyType}, ${mapValueType})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodSet:
-      return `${getMultilineComment(def.description)}z.set(${sUnwrapZod(def.valueType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.set(${sUnwrapZod(def.valueType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodFunction:
       const args = def.args.items.map(sUnwrapZod)
       const argsString = args.length ? `.args(${args.join(', ')})` : ''
       const returns = sUnwrapZod(def.returns)
-      return `${getMultilineComment(def.description)}z.function()${argsString}.returns(${returns})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.function()${argsString}.returns(${returns})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodLazy:
-      return `${getMultilineComment(def.description)}z.lazy(() => ${sUnwrapZod(def.getter())})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.lazy(() => ${sUnwrapZod(def.getter())})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodLiteral:
       const value = primitiveToTypescriptValue(def.value)
-      return `${getMultilineComment(def.description)}z.literal(${value})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.literal(${value})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodEnum:
       const values = def.values.map(primitiveToTypescriptValue)
-      return `${getMultilineComment(def.description)}z.enum([${values.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.enum([${values.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodEffects:
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodEffects)
@@ -137,21 +136,21 @@ function sUnwrapZod(schema: z.Schema): string {
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodNativeEnum)
 
     case z.ZodFirstPartyTypeKind.ZodOptional:
-      return `${getMultilineComment(def.description)}z.optional(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.optional(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNullable:
-      return `${getMultilineComment(def.description)}z.nullable(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.nullable(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodDefault:
       const defaultValue = unknownToTypescriptValue(def.defaultValue())
       // TODO: use z.default() notation
-      return `${getMultilineComment(def.description)}${sUnwrapZod(def.innerType)}${_addZuiExtensions(def)}.default(${defaultValue})${_maybeDescribe(def)}`.trim()
+      return `z.default(${sUnwrapZod(def.innerType)}, ${defaultValue})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodCatch:
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodCatch)
 
     case z.ZodFirstPartyTypeKind.ZodPromise:
-      return `${getMultilineComment(def.description)}z.promise(${sUnwrapZod(def.type)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.promise(${sUnwrapZod(def.type)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodBranded:
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodBranded)
@@ -163,11 +162,11 @@ function sUnwrapZod(schema: z.Schema): string {
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodSymbol)
 
     case z.ZodFirstPartyTypeKind.ZodReadonly:
-      return `${getMultilineComment(def.description)}z.readonly(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.readonly(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodRef:
       const uri = primitiveToTypescriptValue(def.uri)
-      return `${getMultilineComment(def.description)}z.ref(${uri})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.ref(${uri})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
 
     default:
       util.assertNever(def)


### PR DESCRIPTION
- `z.array` now correctly appends description and extensions
- the multi-line comments are removed, since they're redundant now that everything has a `.describe`