### PR TITLE
fix(zui): consistent catchall and extra keys behavior

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.21.0",
+  "version": "0.20.2",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/z/types/discriminatedUnion/index.ts
+++ b/zui/src/z/types/discriminatedUnion/index.ts
@@ -72,8 +72,7 @@ export type ZodDiscriminatedUnionOption<Discriminator extends string> = ZodObjec
   {
     [key in Discriminator]: ZodTypeAny
   } & ZodRawShape,
-  UnknownKeysParam,
-  ZodTypeAny
+  UnknownKeysParam
 >
 
 export interface ZodDiscriminatedUnionDef<

--- a/zui/src/z/types/object/index.ts
+++ b/zui/src/z/types/object/index.ts
@@ -75,12 +75,6 @@ export type UnknownKeysOutputType<T extends UnknownKeysParam> = T extends ZodTyp
     ? { [k: string]: unknown }
     : {}
 
-export type AdditionalProperties<T extends UnknownKeysParam> = T extends ZodTypeAny
-  ? T
-  : T extends 'passthrough'
-    ? ZodUnknown
-    : ZodNever
-
 export type deoptional<T extends ZodTypeAny> =
   T extends ZodOptional<infer U> ? deoptional<U> : T extends ZodNullable<infer U> ? ZodNullable<deoptional<U>> : T
 
@@ -284,16 +278,6 @@ export class ZodObject<
       ...this._def,
       unknownKeys: 'passthrough',
     })
-  }
-
-  additionalProperties(): AdditionalProperties<UnknownKeys> {
-    if (this._def.unknownKeys instanceof ZodType) {
-      return this._def.unknownKeys as AdditionalProperties<UnknownKeys>
-    }
-    if (this._def.unknownKeys === 'passthrough') {
-      return ZodUnknown.create() as AdditionalProperties<UnknownKeys>
-    }
-    return ZodNever.create() as AdditionalProperties<UnknownKeys>
   }
 
   /**

--- a/zui/src/z/types/object/index.ts
+++ b/zui/src/z/types/object/index.ts
@@ -84,7 +84,7 @@ export type AdditionalProperties<T extends UnknownKeysParam> = T extends ZodType
 export type deoptional<T extends ZodTypeAny> =
   T extends ZodOptional<infer U> ? deoptional<U> : T extends ZodNullable<infer U> ? ZodNullable<deoptional<U>> : T
 
-export type SomeZodObject = ZodObject<ZodRawShape, UnknownKeysParam, ZodTypeAny>
+export type SomeZodObject = ZodObject<ZodRawShape, UnknownKeysParam>
 
 export type noUnrecognized<Obj extends object, Shape extends object> = {
   [k in keyof Obj]: k extends keyof Shape ? Obj[k] : never
@@ -120,7 +120,6 @@ function deepPartialify(schema: ZodTypeAny): any {
 export class ZodObject<
   T extends ZodRawShape = ZodRawShape,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
-  _Catchall extends ZodTypeAny = ZodTypeAny, // TODO: remove
   Output = objectOutputType<T, UnknownKeys>,
   Input = objectInputType<T, UnknownKeys>,
 > extends ZodType<Output, ZodObjectDef<T, UnknownKeys>, Input> {
@@ -644,4 +643,4 @@ export class ZodObject<
   }
 }
 
-export type AnyZodObject = ZodObject<any, any, any>
+export type AnyZodObject = ZodObject<any, any>

--- a/zui/src/z/types/object/index.ts
+++ b/zui/src/z/types/object/index.ts
@@ -2,7 +2,6 @@ import { unique } from '../../utils'
 import {
   ZodArray,
   ZodEnum,
-  ZodNever,
   ZodNullable,
   ZodOptional,
   ZodTuple,
@@ -27,19 +26,19 @@ import {
   errorUtil,
   partialUtil,
   createZodEnum,
+  ZodUnknown,
+  ZodNever,
 } from '../index'
 import { CustomSet } from '../utils/custom-set'
 
-export type UnknownKeysParam = 'passthrough' | 'strict' | 'strip'
+export type UnknownKeysParam = 'passthrough' | 'strict' | 'strip' | ZodTypeAny
 
 export interface ZodObjectDef<
   T extends ZodRawShape = ZodRawShape,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
-  Catchall extends ZodTypeAny = ZodTypeAny,
 > extends ZodTypeDef {
   typeName: ZodFirstPartyTypeKind.ZodObject
   shape: () => T
-  catchall: Catchall
   unknownKeys: UnknownKeys
 }
 
@@ -49,11 +48,8 @@ export type mergeTypes<A, B> = {
 
 export type objectOutputType<
   Shape extends ZodRawShape,
-  Catchall extends ZodTypeAny,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
-> = objectUtil.flatten<objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>> &
-  CatchallOutput<Catchall> &
-  PassthroughType<UnknownKeys>
+> = objectUtil.flatten<objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>> & UnknownKeysOutputType<UnknownKeys>
 
 export type baseObjectOutputType<Shape extends ZodRawShape> = {
   [k in keyof Shape]: Shape[k]['_output']
@@ -61,18 +57,29 @@ export type baseObjectOutputType<Shape extends ZodRawShape> = {
 
 export type objectInputType<
   Shape extends ZodRawShape,
-  Catchall extends ZodTypeAny,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
-> = objectUtil.flatten<baseObjectInputType<Shape>> & CatchallInput<Catchall> & PassthroughType<UnknownKeys>
+> = objectUtil.flatten<baseObjectInputType<Shape>> & UnknownKeysInputType<UnknownKeys>
 export type baseObjectInputType<Shape extends ZodRawShape> = objectUtil.addQuestionMarks<{
   [k in keyof Shape]: Shape[k]['_input']
 }>
 
-export type CatchallOutput<T extends ZodType> = ZodType extends T ? unknown : { [k: string]: T['_output'] }
+export type UnknownKeysInputType<T extends UnknownKeysParam> = T extends ZodTypeAny
+  ? { [k: string]: T['_input'] }
+  : T extends 'passthrough'
+    ? { [k: string]: unknown }
+    : {}
 
-export type CatchallInput<T extends ZodType> = ZodType extends T ? unknown : { [k: string]: T['_input'] }
+export type UnknownKeysOutputType<T extends UnknownKeysParam> = T extends ZodTypeAny
+  ? { [k: string]: T['_output'] }
+  : T extends 'passthrough'
+    ? { [k: string]: unknown }
+    : {}
 
-export type PassthroughType<T extends UnknownKeysParam> = T extends 'passthrough' ? { [k: string]: unknown } : unknown
+export type AdditionalProperties<T extends UnknownKeysParam> = T extends ZodTypeAny
+  ? T
+  : T extends 'passthrough'
+    ? ZodUnknown
+    : ZodNever
 
 export type deoptional<T extends ZodTypeAny> =
   T extends ZodOptional<infer U> ? deoptional<U> : T extends ZodNullable<infer U> ? ZodNullable<deoptional<U>> : T
@@ -113,10 +120,10 @@ function deepPartialify(schema: ZodTypeAny): any {
 export class ZodObject<
   T extends ZodRawShape = ZodRawShape,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
-  Catchall extends ZodTypeAny = ZodTypeAny,
-  Output = objectOutputType<T, Catchall, UnknownKeys>,
-  Input = objectInputType<T, Catchall, UnknownKeys>,
-> extends ZodType<Output, ZodObjectDef<T, UnknownKeys, Catchall>, Input> {
+  _Catchall extends ZodTypeAny = ZodTypeAny, // TODO: remove
+  Output = objectOutputType<T, UnknownKeys>,
+  Input = objectInputType<T, UnknownKeys>,
+> extends ZodType<Output, ZodObjectDef<T, UnknownKeys>, Input> {
   private _cached: { shape: T; keys: string[] } | null = null
 
   _getCached(): { shape: T; keys: string[] } {
@@ -164,7 +171,7 @@ export class ZodObject<
     const { shape, keys: shapeKeys } = this._getCached()
     const extraKeys: string[] = []
 
-    if (!(this._def.catchall instanceof ZodNever && this._def.unknownKeys === 'strip')) {
+    if (this._def.unknownKeys !== 'strip') {
       for (const key in ctx.data) {
         if (!shapeKeys.includes(key)) {
           extraKeys.push(key)
@@ -187,37 +194,30 @@ export class ZodObject<
       })
     }
 
-    if (this._def.catchall instanceof ZodNever) {
-      const unknownKeys = this._def.unknownKeys
-
-      if (unknownKeys === 'passthrough') {
-        for (const key of extraKeys) {
-          pairs.push({
-            key: { status: 'valid', value: key },
-            value: { status: 'valid', value: ctx.data[key] },
-          })
-        }
-      } else if (unknownKeys === 'strict') {
-        if (extraKeys.length > 0) {
-          addIssueToContext(ctx, {
-            code: ZodIssueCode.unrecognized_keys,
-            keys: extraKeys,
-          })
-          status.dirty()
-        }
-      } else if (unknownKeys === 'strip') {
-      } else {
-        throw new Error(`Internal ZodObject error: invalid unknownKeys value.`)
+    const unknownKeys = this._def.unknownKeys
+    if (unknownKeys === 'passthrough') {
+      for (const key of extraKeys) {
+        pairs.push({
+          key: { status: 'valid', value: key },
+          value: { status: 'valid', value: ctx.data[key] },
+        })
       }
+    } else if (unknownKeys === 'strict') {
+      if (extraKeys.length > 0) {
+        addIssueToContext(ctx, {
+          code: ZodIssueCode.unrecognized_keys,
+          keys: extraKeys,
+        })
+        status.dirty()
+      }
+    } else if (unknownKeys === 'strip') {
     } else {
       // run catchall validation
-      const catchall = this._def.catchall
-
       for (const key of extraKeys) {
         const value = ctx.data[key]
         pairs.push({
           key: { status: 'valid', value: key },
-          value: catchall._parse(
+          value: unknownKeys._parse(
             new ParseInputLazyPath(ctx, value, ctx.path, key), //, ctx.child(key), value, getParsedType(value)
           ),
           alwaysSet: key in ctx.data,
@@ -251,7 +251,7 @@ export class ZodObject<
     return this._def.shape()
   }
 
-  strict(message?: errorUtil.ErrMessage): ZodObject<T, 'strict', Catchall> {
+  strict(message?: errorUtil.ErrMessage): ZodObject<T, 'strict'> {
     errorUtil.errToObj
     return new ZodObject({
       ...this._def,
@@ -273,18 +273,28 @@ export class ZodObject<
     })
   }
 
-  strip(): ZodObject<T, 'strip', Catchall> {
+  strip(): ZodObject<T, 'strip'> {
     return new ZodObject({
       ...this._def,
       unknownKeys: 'strip',
     })
   }
 
-  passthrough(): ZodObject<T, 'passthrough', Catchall> {
+  passthrough(): ZodObject<T, 'passthrough'> {
     return new ZodObject({
       ...this._def,
       unknownKeys: 'passthrough',
     })
+  }
+
+  additionalProperties(): AdditionalProperties<UnknownKeys> {
+    if (this._def.unknownKeys instanceof ZodType) {
+      return this._def.unknownKeys as AdditionalProperties<UnknownKeys>
+    }
+    if (this._def.unknownKeys === 'passthrough') {
+      return ZodUnknown.create() as AdditionalProperties<UnknownKeys>
+    }
+    return ZodNever.create() as AdditionalProperties<UnknownKeys>
   }
 
   /**
@@ -312,7 +322,7 @@ export class ZodObject<
   //   };
   extend<Augmentation extends ZodRawShape>(
     augmentation: Augmentation,
-  ): ZodObject<objectUtil.extendShape<T, Augmentation>, UnknownKeys, Catchall> {
+  ): ZodObject<objectUtil.extendShape<T, Augmentation>, UnknownKeys> {
     return new ZodObject({
       ...this._def,
       shape: () => ({
@@ -366,10 +376,9 @@ export class ZodObject<
    */
   merge<Incoming extends AnyZodObject, Augmentation extends Incoming['shape']>(
     merging: Incoming,
-  ): ZodObject<objectUtil.extendShape<T, Augmentation>, Incoming['_def']['unknownKeys'], Incoming['_def']['catchall']> {
+  ): ZodObject<objectUtil.extendShape<T, Augmentation>, Incoming['_def']['unknownKeys']> {
     const merged: any = new ZodObject({
       unknownKeys: merging._def.unknownKeys,
-      catchall: merging._def.catchall,
       shape: () => ({
         ...this._def.shape(),
         ...merging._def.shape(),
@@ -420,15 +429,13 @@ export class ZodObject<
     T & {
       [k in Key]: Schema
     },
-    UnknownKeys,
-    Catchall
+    UnknownKeys
   > {
     return this.augment({ [key]: schema }) as ZodObject<
       T & {
         [k in Key]: Schema
       },
-      UnknownKeys,
-      Catchall
+      UnknownKeys
     >
   }
   // merge<Incoming extends AnyZodObject>(
@@ -452,10 +459,10 @@ export class ZodObject<
   //   });
   //   return merged;
   // }
-  catchall<Index extends ZodTypeAny>(index: Index): ZodObject<T, UnknownKeys, Index> {
+  catchall<Index extends ZodTypeAny>(index: Index): ZodObject<T, Index> {
     return new ZodObject({
       ...this._def,
-      catchall: index,
+      unknownKeys: index,
     })
   }
 
@@ -463,7 +470,7 @@ export class ZodObject<
     Mask extends {
       [k in keyof T]?: true
     },
-  >(mask: Mask): ZodObject<Pick<T, Extract<keyof T, keyof Mask>>, UnknownKeys, Catchall> {
+  >(mask: Mask): ZodObject<Pick<T, Extract<keyof T, keyof Mask>>, UnknownKeys> {
     const shape: any = {}
 
     util.objectKeys(mask).forEach((key) => {
@@ -482,7 +489,7 @@ export class ZodObject<
     Mask extends {
       [k in keyof T]?: true
     },
-  >(mask: Mask): ZodObject<Omit<T, keyof Mask>, UnknownKeys, Catchall> {
+  >(mask: Mask): ZodObject<Omit<T, keyof Mask>, UnknownKeys> {
     const shape: any = {}
 
     util.objectKeys(this.shape).forEach((key) => {
@@ -508,8 +515,7 @@ export class ZodObject<
     {
       [k in keyof T]: ZodOptional<T[k]>
     },
-    UnknownKeys,
-    Catchall
+    UnknownKeys
   >
   partial<
     Mask extends {
@@ -521,8 +527,7 @@ export class ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k]
     }>,
-    UnknownKeys,
-    Catchall
+    UnknownKeys
   >
   partial(mask?: any) {
     const newShape: Record<string, ZodTypeAny | undefined> = {}
@@ -547,8 +552,7 @@ export class ZodObject<
     {
       [k in keyof T]: deoptional<T[k]>
     },
-    UnknownKeys,
-    Catchall
+    UnknownKeys
   >
   required<
     Mask extends {
@@ -560,8 +564,7 @@ export class ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? deoptional<T[k]> : T[k]
     }>,
-    UnknownKeys,
-    Catchall
+    UnknownKeys
   >
   required(mask?: any) {
     const newShape: any = {}
@@ -593,8 +596,7 @@ export class ZodObject<
 
   isEqual(schema: ZodType): boolean {
     if (!(schema instanceof ZodObject)) return false
-    if (!this._def.catchall.isEqual(schema._def.catchall)) return false
-    if (this._def.unknownKeys !== schema._def.unknownKeys) return false
+    if (!this._unknownKeysEqual(schema._def.unknownKeys)) return false
 
     const thisShape = this._def.shape()
     const thatShape = schema._def.shape()
@@ -607,11 +609,17 @@ export class ZodObject<
     return thisProps.isEqual(thatProps)
   }
 
+  private _unknownKeysEqual(that: UnknownKeysParam): boolean {
+    if (this._def.unknownKeys instanceof ZodType && that instanceof ZodType) {
+      return this._def.unknownKeys.isEqual(that)
+    }
+    return this._def.unknownKeys === that
+  }
+
   static create = <T extends ZodRawShape>(shape: T, params?: RawCreateParams): ZodObject<T, 'strip'> => {
     return new ZodObject({
       shape: () => shape,
       unknownKeys: 'strip',
-      catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     })
@@ -621,7 +629,6 @@ export class ZodObject<
     return new ZodObject({
       shape: () => shape,
       unknownKeys: 'strict',
-      catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     })
@@ -631,7 +638,6 @@ export class ZodObject<
     return new ZodObject({
       shape,
       unknownKeys: 'strip',
-      catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     })

--- a/zui/src/z/types/object/object.test.ts
+++ b/zui/src/z/types/object/object.test.ts
@@ -357,8 +357,8 @@ test('unknownkeys merging', () => {
   const mergedSchema = schemaA.merge(schemaB)
   type mergedSchema = typeof mergedSchema
 
-  util.assertEqual<mergedSchema['_def']['catchall'], z.ZodString>(true)
-  expect(mergedSchema._def.catchall instanceof z.ZodString).toEqual(true)
+  util.assertEqual<mergedSchema['_def']['unknownKeys'], z.ZodString>(true)
+  expect(mergedSchema._def.unknownKeys instanceof z.ZodString).toEqual(true)
 })
 
 const personToExtend = z.object({

--- a/zui/src/z/types/object/object.test.ts
+++ b/zui/src/z/types/object/object.test.ts
@@ -156,7 +156,7 @@ test('test that optional keys are unset', async () => {
     set: z.string().optional(),
     unset: z.string().optional(),
   })
-  const result = await SNamedEntity.parse({
+  const result = SNamedEntity.parse({
     id: 'asdf',
     set: undefined,
   })
@@ -329,21 +329,6 @@ test('intersection of object with refine with date', async () => {
 })
 
 test('constructor key', () => {
-  const person = z
-    .object({
-      name: z.string(),
-    })
-    .strict()
-
-  expect(() =>
-    person.parse({
-      name: 'bob dylan',
-      constructor: 61,
-    }),
-  ).toThrow()
-})
-
-test('constructor key', () => {
   const Example = z.object({
     prop: z.string(),
     opt: z.number().optional(),
@@ -371,8 +356,6 @@ test('unknownkeys merging', () => {
 
   const mergedSchema = schemaA.merge(schemaB)
   type mergedSchema = typeof mergedSchema
-  util.assertEqual<mergedSchema['_def']['unknownKeys'], 'strip'>(true)
-  expect(mergedSchema._def.unknownKeys).toEqual('strip')
 
   util.assertEqual<mergedSchema['_def']['catchall'], z.ZodString>(true)
   expect(mergedSchema._def.catchall instanceof z.ZodString).toEqual(true)
@@ -427,5 +410,96 @@ test('xor', () => {
   type Outer = { data: C }
   const Outer: z.ZodType<Outer> = z.object({
     data: z.union([z.object({ name: z.string(), a: z.number() }), z.object({ name: z.string(), b: z.number() })]),
+  })
+})
+
+test('object with strip should strip keys', () => {
+  const schema = z.object({ foo: z.string() }).strip()
+  const result = schema.safeParse({ foo: '123', bar: 123 })
+  expect(result).toEqual({
+    success: true,
+    data: { foo: '123' },
+  })
+})
+
+test('object with passthrough should allow all extra keys', () => {
+  const schema = z.object({ foo: z.string() }).passthrough()
+  const result = schema.safeParse({ foo: '123', bar: 123 })
+  expect(result).toEqual({
+    success: true,
+    data: { foo: '123', bar: 123 },
+  })
+})
+
+test('object with strict should fail if extra keys', () => {
+  const schema = z.object({ foo: z.string() }).strict()
+  const result = schema.safeParse({ foo: '123', bar: 123 })
+  expect(result).toMatchObject({
+    success: false,
+  })
+})
+
+test('object with catchall any should allow all keys', () => {
+  const schema = z.object({ foo: z.string() }).catchall(z.any())
+  const result = schema.safeParse({ foo: '123', bar: 123 })
+  expect(result).toEqual({
+    success: true,
+    data: { foo: '123', bar: 123 },
+  })
+})
+
+test('object with catchall never should fail if extra keys', () => {
+  const schema = z.object({ foo: z.string() }).catchall(z.never())
+  const result = schema.safeParse({ foo: '123', bar: 123 })
+  expect(result).toMatchObject({
+    success: false,
+  })
+})
+
+test('object with catchall number should succeed for extra number keys but fail otherwise', () => {
+  const schema = z.object({ foo: z.string() }).catchall(z.number())
+  const result1 = schema.safeParse({ foo: '123', bar: 123 })
+  expect(result1).toEqual({
+    success: true,
+    data: { foo: '123', bar: 123 },
+  })
+
+  const result2 = schema.safeParse({ foo: '123', bar: '456' })
+  expect(result2).toMatchObject({
+    success: false,
+  })
+})
+
+test('object with conflicting passthrough and catchall never should behave as the last modifier', () => {
+  const schema = z.object({ foo: z.string() }).passthrough().catchall(z.never())
+  const result = schema.safeParse({ foo: '123', bar: '456' })
+  expect(result).toMatchObject({
+    success: false,
+  })
+})
+
+test('object with conflicting passthrough and catchall number should behave as the last modifier', () => {
+  const schema = z.object({ foo: z.string() }).passthrough().catchall(z.number())
+  const result = schema.safeParse({ foo: '123', bar: '456' })
+  expect(result).toMatchObject({
+    success: false,
+  })
+})
+
+test('object with conflicting strict and catchall any should behave as the last modifier', () => {
+  const schema = z.object({ foo: z.string() }).strict().catchall(z.any())
+  const result = schema.safeParse({ foo: '123', bar: '456' })
+  expect(result).toEqual({
+    success: true,
+    data: { foo: '123', bar: '456' },
+  })
+})
+
+test('object with conflicting strict and catchall number should behave as the last modifier', () => {
+  const schema = z.object({ foo: z.string() }).strict().catchall(z.number())
+  const result = schema.safeParse({ foo: '123', bar: 456 })
+  expect(result).toEqual({
+    success: true,
+    data: { foo: '123', bar: 456 },
   })
 })

--- a/zui/src/z/types/utils/partialUtil.ts
+++ b/zui/src/z/types/utils/partialUtil.ts
@@ -11,11 +11,7 @@ import type {
 export namespace partialUtil {
   export type DeepPartial<T extends ZodTypeAny> =
     T extends ZodObject<ZodRawShape>
-      ? ZodObject<
-          { [k in keyof T['shape']]: ZodOptional<DeepPartial<T['shape'][k]>> },
-          T['_def']['unknownKeys'],
-          T['_def']['catchall']
-        >
+      ? ZodObject<{ [k in keyof T['shape']]: ZodOptional<DeepPartial<T['shape'][k]>> }, T['_def']['unknownKeys']>
       : T extends ZodArray<infer Type, infer Card>
         ? ZodArray<DeepPartial<Type>, Card>
         : T extends ZodOptional<infer Type>


### PR DESCRIPTION
# Problem

In a Zod object, `catchall` and `unknownKeys` should be mutually exclusive. Allowing both leads to inconsistent and unintuitive behavior:

```ts
const schema1 = z.object({ foo: z.string() }).passthrough().catchall(z.string())
const schema2 = z.object({ foo: z.string() }).passthrough().catchall(z.never())

console.log(schema1.safeParse({ foo: 'bar', baz: 42 }).success) // false
console.log(schema2.safeParse({ foo: 'bar', baz: 42 }).success) // true
```

This is confusing—especially because `.passthrough()` implies all unknown keys are allowed, while `.catchall(z.never())` explicitly disallows them.

# Solution 1: Separate `strip` and `catchall`

The first attempted solution involved modeling all behaviors around additional properties using two separate keys: `strip: boolean` and `catchall: ZodTypeAny`.

```ts
export interface ZodObjectDef<T extends ZodRawShape = ZodRawShape, Catchall extends ZodTypeAny = ZodTypeAny>
  extends ZodTypeDef {
  typeName: ZodFirstPartyTypeKind.ZodObject
  shape: () => T
  strip: boolean
  catchall: Catchall
}
```

With this design, methods were implemented as:

```ts
strip() {
  return new ZodObject({
      ...this._def,
      strip: true,
      catchall: ZodNever.create()
    })
}

strict() {
  return new ZodObject({
      ...this._def,
      strip: false,
      catchall: ZodNever.create()
    })
}

passthrough() {
  return new ZodObject({
      ...this._def,
      strip: false,
      catchall: ZodUnknown.create()
    })
}

catchall(schema: ZodTypeAny) {
  return new ZodObject({
      ...this._def,
      strip: false,
      catchall: schema
    })
}
```

While this approach handled the semantics well, it had a downside: error messages became less user-friendly. For example:

```ts
const person = z.object({ name: z.string() }).strict()
const result = person.parse({ name: 'bob dylan', extraKey: 61 })
```

This produced: `"Expected never, received number"`
Rather than the clearer: `"Unrecognized key(s) in object: 'extraKey'"`

# Solution 2: Unified `unknownKeys`

The solution proposed in this PR unifies the configuration into a single field:
`unknownKeys: 'passthrough' | 'strict' | 'strip' | ZodTypeAny`

This avoids invalid or ambiguous combinations, and preserves helpful error messages.

Updated implementations:

```ts
strip() {
  return new ZodObject({
      ...this._def,
      unknownKeys: 'strip'
    })
}

strict() {
  return new ZodObject({
      ...this._def,
      unknownKeys: 'strict'
    })
}

passthrough() {
  return new ZodObject({
      ...this._def,
      unknownKeys: 'passthrough'
    })
}

catchall(schema: ZodTypeAny) {
  return new ZodObject({
      ...this._def,
      unknownKeys: schema
    })
}
```

This ensures mutual exclusivity, removes undefined behavior, and keeps developer-facing messages intuitive.
