### PR TITLE
feat(zui): allow deep cloning a zui schema

### DIFF
--- a/zui/src/z/clone.test.ts
+++ b/zui/src/z/clone.test.ts
@@ -1,0 +1,255 @@
+import { test, expect } from 'vitest'
+import { z } from '.'
+
+const expectZui = (actual: z.Schema) => ({
+  not: {
+    toEqual: (expected: z.Schema) => {
+      const result = actual.isEqual(expected)
+      let msg: string | undefined = undefined
+      try {
+        msg = `Expected ${actual.toTypescriptSchema()} not to equal ${expected.toTypescriptSchema()}`
+      } catch {}
+      expect(result, msg).toBe(true)
+    },
+  },
+  toEqual: (expected: z.Schema) => {
+    const result = actual.isEqual(expected)
+    let msg: string | undefined = undefined
+    try {
+      msg = `Expected ${actual.toTypescriptSchema()} to equal ${expected.toTypescriptSchema()}`
+    } catch {}
+    expect(result, msg).toBe(true)
+  },
+})
+
+test('clone any', () => {
+  const schema = z.any()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone array', () => {
+  const schema = z.array(z.string())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone bigint', () => {
+  const schema = z.bigint()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone boolean', () => {
+  const schema = z.boolean()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone branded', () => {
+  const schema = z.string().brand('test')
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone catch', () => {
+  const schema = z.string().catch('test')
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone custom', () => {
+  const schema = z.custom()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone date', () => {
+  const schema = z.date()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone default', () => {
+  const schema = z.string().default('test')
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone discriminatedUnion', () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal('a'), value: z.string() }),
+    z.object({ type: z.literal('b'), value: z.number() }),
+  ])
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone enum', () => {
+  const schema = z.enum(['a', 'b', 'c'])
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone function', () => {
+  const schema = z.function().args(z.string()).returns(z.number())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone intersection', () => {
+  const schema = z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() }))
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone lazy', () => {
+  const schema = z.lazy(() => z.string())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone literal', () => {
+  const schema = z.literal('test')
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone map', () => {
+  const schema = z.map(z.string(), z.number())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone nan', () => {
+  const schema = z.nan()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone nativeEnum', () => {
+  const schema = z.nativeEnum({ a: 'a', b: 'b', c: 'c' })
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone never', () => {
+  const schema = z.never()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone null', () => {
+  const schema = z.null()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone nullable', () => {
+  const schema = z.string().nullable()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone number', () => {
+  const schema = z.number()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone object', () => {
+  const schema = z.object({ a: z.string(), b: z.number() })
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone optional', () => {
+  const schema = z.string().optional()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone pipeline', () => {
+  const schema = z.pipeline(z.string(), z.number())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone promise', () => {
+  const schema = z.promise(z.string())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone readonly', () => {
+  const schema = z.string().readonly()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone record', () => {
+  const schema = z.record(z.string())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone ref', () => {
+  const schema = z.ref('test')
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone set', () => {
+  const schema = z.set(z.string())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone string', () => {
+  const schema = z.string()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone symbol', () => {
+  const schema = z.symbol()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone transformer', () => {
+  const schema = z.string().transform((val) => val.toUpperCase())
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone tuple', () => {
+  const schema = z.tuple([z.string(), z.number()])
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone undefined', () => {
+  const schema = z.undefined()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone union', () => {
+  const schema = z.union([z.string(), z.number()])
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone unknown', () => {
+  const schema = z.unknown()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})
+test('clone void', () => {
+  const schema = z.void()
+  const clone = schema.clone()
+  expectZui(clone).toEqual(schema)
+  expect(clone).not.toBe(schema)
+})

--- a/zui/src/z/types/array/index.ts
+++ b/zui/src/z/types/array/index.ts
@@ -47,6 +47,13 @@ export class ZodArray<T extends ZodTypeAny = ZodTypeAny, Cardinality extends Arr
     return this._def.type.getReferences()
   }
 
+  clone(): ZodArray<T, Cardinality> {
+    return new ZodArray({
+      ...this._def,
+      type: this._def.type.clone(),
+    }) as ZodArray<T, Cardinality>
+  }
+
   isEqual(schema: ZodType): boolean {
     if (!(schema instanceof ZodArray)) {
       return false

--- a/zui/src/z/types/basetype/index.ts
+++ b/zui/src/z/types/basetype/index.ts
@@ -167,6 +167,13 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
     return []
   }
 
+  clone(): ZodType<Output, Def, Input> {
+    const This = (this as any).constructor
+    return new This({
+      ...this._def,
+    })
+  }
+
   /** checks if a schema is equal to another */
   abstract isEqual(schema: ZodType): boolean
 

--- a/zui/src/z/types/branded/index.ts
+++ b/zui/src/z/types/branded/index.ts
@@ -19,6 +19,24 @@ export class ZodBranded<T extends ZodTypeAny = ZodTypeAny, B extends Key = Key> 
   ZodBrandedDef<T>,
   T['_input']
 > {
+  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+    return new ZodBranded({
+      ...this._def,
+      type: this._def.type.dereference(defs),
+    })
+  }
+
+  getReferences(): string[] {
+    return this._def.type.getReferences()
+  }
+
+  clone(): ZodBranded<T, B> {
+    return new ZodBranded({
+      ...this._def,
+      type: this._def.type.clone(),
+    }) as ZodBranded<T, B>
+  }
+
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input)
     const data = ctx.data

--- a/zui/src/z/types/catch/index.ts
+++ b/zui/src/z/types/catch/index.ts
@@ -102,6 +102,24 @@ export class ZodCatch<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     )
   }
 
+  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+    return new ZodCatch({
+      ...this._def,
+      innerType: this._def.innerType.dereference(defs),
+    })
+  }
+
+  getReferences(): string[] {
+    return this._def.innerType.getReferences()
+  }
+
+  clone(): ZodCatch<T> {
+    return new ZodCatch({
+      ...this._def,
+      innerType: this._def.innerType.clone(),
+    }) as ZodCatch<T>
+  }
+
   naked() {
     return this._def.innerType.naked()
   }

--- a/zui/src/z/types/default/index.ts
+++ b/zui/src/z/types/default/index.ts
@@ -48,6 +48,17 @@ export class ZodDefault<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     })
   }
 
+  getReferences(): string[] {
+    return this._def.innerType.getReferences()
+  }
+
+  clone(): ZodDefault<T> {
+    return new ZodDefault({
+      ...this._def,
+      innerType: this._def.innerType.clone(),
+    }) as ZodDefault<T>
+  }
+
   static create = <T extends ZodTypeAny>(
     type: T,
     value: T['_input'] | (() => util.noUndefined<T['_input']>),

--- a/zui/src/z/types/discriminatedUnion/index.ts
+++ b/zui/src/z/types/discriminatedUnion/index.ts
@@ -108,6 +108,16 @@ export class ZodDiscriminatedUnion<
     return unique(this.options.flatMap((option) => option.getReferences()))
   }
 
+  clone(): ZodDiscriminatedUnion<Discriminator, Options> {
+    const options: ZodDiscriminatedUnionOption<Discriminator>[] = this.options.map(
+      (option) => option.clone() as ZodDiscriminatedUnionOption<Discriminator>,
+    )
+    return new ZodDiscriminatedUnion({
+      ...this._def,
+      options: options as [ZodDiscriminatedUnionOption<Discriminator>, ...ZodDiscriminatedUnionOption<Discriminator>[]],
+    }) as ZodDiscriminatedUnion<Discriminator, any>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { ctx } = this._processInputParams(input)
 

--- a/zui/src/z/types/function/index.ts
+++ b/zui/src/z/types/function/index.ts
@@ -60,6 +60,14 @@ export class ZodFunction<
     return unique([...this._def.args.getReferences(), ...this._def.returns.getReferences()])
   }
 
+  clone(): ZodFunction<Args, Returns> {
+    return new ZodFunction({
+      ...this._def,
+      args: this._def.args.clone() as ZodTuple<any, any>,
+      returns: this._def.returns.clone(),
+    }) as ZodFunction<Args, Returns>
+  }
+
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input)
     if (ctx.parsedType !== ZodParsedType.function) {

--- a/zui/src/z/types/intersection/index.ts
+++ b/zui/src/z/types/intersection/index.ts
@@ -90,6 +90,14 @@ export class ZodIntersection<T extends ZodTypeAny = ZodTypeAny, U extends ZodTyp
     return unique([...this._def.left.getReferences(), ...this._def.right.getReferences()])
   }
 
+  clone(): ZodIntersection<T, U> {
+    return new ZodIntersection({
+      ...this._def,
+      left: this._def.left.clone(),
+      right: this._def.right.clone(),
+    }) as ZodIntersection<T, U>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { status, ctx } = this._processInputParams(input)
     const handleParsed = (

--- a/zui/src/z/types/lazy/index.ts
+++ b/zui/src/z/types/lazy/index.ts
@@ -21,6 +21,24 @@ export class ZodLazy<T extends ZodTypeAny = ZodTypeAny> extends ZodType<output<T
     return this._def.getter()
   }
 
+  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+    return new ZodLazy({
+      ...this._def,
+      getter: () => this._def.getter().dereference(defs),
+    })
+  }
+
+  getReferences(): string[] {
+    return this._def.getter().getReferences()
+  }
+
+  clone(): ZodLazy<T> {
+    return new ZodLazy({
+      ...this._def,
+      getter: () => this._def.getter().clone(),
+    }) as ZodLazy<T>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { ctx } = this._processInputParams(input)
     const lazySchema = this._def.getter()

--- a/zui/src/z/types/map/index.ts
+++ b/zui/src/z/types/map/index.ts
@@ -49,6 +49,14 @@ export class ZodMap<Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAn
     return unique([...this._def.keyType.getReferences(), ...this._def.valueType.getReferences()])
   }
 
+  clone(): ZodMap<Key, Value> {
+    return new ZodMap({
+      ...this._def,
+      keyType: this._def.keyType.clone(),
+      valueType: this._def.valueType.clone(),
+    }) as ZodMap<Key, Value>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { status, ctx } = this._processInputParams(input)
     if (ctx.parsedType !== ZodParsedType.map) {

--- a/zui/src/z/types/nullable/index.ts
+++ b/zui/src/z/types/nullable/index.ts
@@ -34,6 +34,13 @@ export class ZodNullable<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType.getReferences()
   }
 
+  clone(): ZodNullable<T> {
+    return new ZodNullable({
+      ...this._def,
+      innerType: this._def.innerType.clone(),
+    }) as ZodNullable<T>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const parsedType = this._getType(input)
     if (parsedType === ZodParsedType.null) {

--- a/zui/src/z/types/object/index.ts
+++ b/zui/src/z/types/object/index.ts
@@ -155,6 +155,18 @@ export class ZodObject<
     return unique(refs)
   }
 
+  clone(): ZodObject<T, UnknownKeys, Output, Input> {
+    const newShape: Record<string, ZodTypeAny> = {}
+    const currentShape = this._def.shape()
+    for (const [key, value] of Object.entries(currentShape)) {
+      newShape[key] = value.clone()
+    }
+    return new ZodObject({
+      ...this._def,
+      shape: () => newShape,
+    }) as ZodObject<T, UnknownKeys, Output, Input>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const parsedType = this._getType(input)
     if (parsedType !== ZodParsedType.object) {

--- a/zui/src/z/types/optional/index.ts
+++ b/zui/src/z/types/optional/index.ts
@@ -34,6 +34,13 @@ export class ZodOptional<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType.getReferences()
   }
 
+  clone(): ZodOptional<T> {
+    return new ZodOptional({
+      ...this._def,
+      innerType: this._def.innerType.clone(),
+    }) as ZodOptional<T>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const parsedType = this._getType(input)
     if (parsedType === ZodParsedType.undefined) {

--- a/zui/src/z/types/pipeline/index.ts
+++ b/zui/src/z/types/pipeline/index.ts
@@ -34,6 +34,14 @@ export class ZodPipeline<A extends ZodTypeAny = ZodTypeAny, B extends ZodTypeAny
     return unique([...this._def.in.getReferences(), ...this._def.out.getReferences()])
   }
 
+  clone(): ZodPipeline<A, B> {
+    return new ZodPipeline({
+      ...this._def,
+      in: this._def.in.clone(),
+      out: this._def.out.clone(),
+    }) as ZodPipeline<A, B>
+  }
+
   _parse(input: ParseInput): ParseReturnType<any> {
     const { status, ctx } = this._processInputParams(input)
     if (ctx.common.async) {

--- a/zui/src/z/types/promise/index.ts
+++ b/zui/src/z/types/promise/index.ts
@@ -39,6 +39,13 @@ export class ZodPromise<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.type.getReferences()
   }
 
+  clone(): ZodPromise<T> {
+    return new ZodPromise({
+      ...this._def,
+      type: this._def.type.clone(),
+    }) as ZodPromise<T>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { ctx } = this._processInputParams(input)
     if (ctx.parsedType !== ZodParsedType.promise && ctx.common.async === false) {

--- a/zui/src/z/types/readonly/index.ts
+++ b/zui/src/z/types/readonly/index.ts
@@ -53,6 +53,13 @@ export class ZodReadonly<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType.getReferences()
   }
 
+  clone(): ZodReadonly<T> {
+    return new ZodReadonly({
+      ...this._def,
+      innerType: this._def.innerType.clone(),
+    }) as ZodReadonly<T>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const result = this._def.innerType._parse(input)
     if (isValid(result)) {

--- a/zui/src/z/types/record/index.ts
+++ b/zui/src/z/types/record/index.ts
@@ -63,6 +63,14 @@ export class ZodRecord<Key extends KeySchema = ZodString, Value extends ZodTypeA
     return unique([...this._def.keyType.getReferences(), ...this._def.valueType.getReferences()])
   }
 
+  clone(): ZodRecord<Key, Value> {
+    return new ZodRecord({
+      ...this._def,
+      keyType: this._def.keyType.clone(),
+      valueType: this._def.valueType.clone(),
+    }) as ZodRecord<Key, Value>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { status, ctx } = this._processInputParams(input)
     if (ctx.parsedType !== ZodParsedType.object) {

--- a/zui/src/z/types/set/index.ts
+++ b/zui/src/z/types/set/index.ts
@@ -39,6 +39,13 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.valueType.getReferences()
   }
 
+  clone(): ZodSet<Value> {
+    return new ZodSet({
+      ...this._def,
+      valueType: this._def.valueType.clone(),
+    }) as ZodSet<Value>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { status, ctx } = this._processInputParams(input)
     if (ctx.parsedType !== ZodParsedType.set) {

--- a/zui/src/z/types/transformer/index.ts
+++ b/zui/src/z/types/transformer/index.ts
@@ -70,6 +70,13 @@ export class ZodEffects<T extends ZodTypeAny = ZodTypeAny, Output = output<T>, I
     return this._def.schema.getReferences()
   }
 
+  clone(): ZodEffects<T, Output, Input> {
+    return new ZodEffects({
+      ...this._def,
+      schema: this._def.schema.clone(),
+    }) as ZodEffects<T, Output, Input>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { status, ctx } = this._processInputParams(input)
 

--- a/zui/src/z/types/tuple/index.ts
+++ b/zui/src/z/types/tuple/index.ts
@@ -65,6 +65,16 @@ export class ZodTuple<
     ])
   }
 
+  clone(): ZodTuple<T, Rest> {
+    const items = this._def.items.map((item) => item.clone()) as [ZodTypeAny, ...ZodTypeAny[]]
+    const rest = this._def.rest ? this._def.rest.clone() : null
+    return new ZodTuple({
+      ...this._def,
+      items,
+      rest,
+    }) as ZodTuple<T, Rest>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { status, ctx } = this._processInputParams(input)
     if (ctx.parsedType !== ZodParsedType.array) {

--- a/zui/src/z/types/union/index.ts
+++ b/zui/src/z/types/union/index.ts
@@ -53,6 +53,14 @@ export class ZodUnion<T extends ZodUnionOptions = DefaultZodUnionOptions> extend
     )
   }
 
+  clone(): ZodUnion<T> {
+    const options = this._def.options.map((option) => option.clone()) as [ZodTypeAny, ...ZodTypeAny[]]
+    return new ZodUnion({
+      ...this._def,
+      options,
+    }) as ZodUnion<any>
+  }
+
   _parse(input: ParseInput): ParseReturnType<this['_output']> {
     const { ctx } = this._processInputParams(input)
     const options = this._def.options


### PR DESCRIPTION
All metadata modifiers, like `.title()`, `.disabled()`, `.displayAs()`, `.placeholder()`, and eventually `.describe()`, update the metadata root in place and then return a self-reference. To prevent surprises, it would be safer to return a deep clone of the schema.

This PR offers a way to clone a schema recursively using `schema.clone()`. It is not yet used internally.