### PR TITLE
chore(zui): rm the special lossless discriminated union json-schema transform

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/transforms/common/json-schema.ts
+++ b/zui/src/transforms/common/json-schema.ts
@@ -9,10 +9,6 @@ import { ZuiExtensionObject } from '../../ui/types'
  * Mutiple zui schemas map to the same JSON schema; undefined/never, any/unknown, union/discriminated-union
  * Adding some ZodDef to the ZuiExtension allows us to differentiate between them
  */
-type DiscriminatedUnionDef = util.Satisfies<
-  { typeName: z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion; discriminator: string },
-  Partial<z.ZodDiscriminatedUnionDef>
->
 type NullableDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodNullable }, Partial<z.ZodNullableDef>>
 type OptionalDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodOptional }, Partial<z.ZodOptionalDef>>
 type UndefinedDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodUndefined }, Partial<z.ZodUndefinedDef>>
@@ -109,7 +105,7 @@ export type AnySchema = BaseZuiJsonSchema
 export type UnknownSchema = BaseZuiJsonSchema<UnknownDef>
 export type ArraySchema = _ArraySchema & BaseZuiJsonSchema
 export type UnionSchema = _UnionSchema & BaseZuiJsonSchema
-export type DiscriminatedUnionSchema = _DiscriminatedUnionSchema & BaseZuiJsonSchema<DiscriminatedUnionDef>
+export type DiscriminatedUnionSchema = _DiscriminatedUnionSchema & BaseZuiJsonSchema
 export type IntersectionSchema = _IntersectionSchema & BaseZuiJsonSchema
 export type SetSchema = _SetSchema & BaseZuiJsonSchema
 export type EnumSchema = _EnumSchema & BaseZuiJsonSchema

--- a/zui/src/transforms/json-schema-to-zui-next/guards.ts
+++ b/zui/src/transforms/json-schema-to-zui-next/guards.ts
@@ -14,10 +14,6 @@ export const isNullableSchema = (s: JSONSchema7): s is json.NullableSchema =>
   s.anyOf.some((s) => typeof s !== 'boolean' && s.type === 'null') &&
   (s as json.NullableSchema)['x-zui']?.def?.typeName === z.ZodFirstPartyTypeKind.ZodNullable
 
-export const isDiscriminatedUnionSchema = (s: JSONSchema7): s is json.DiscriminatedUnionSchema =>
-  s.anyOf !== undefined &&
-  (s as json.DiscriminatedUnionSchema)['x-zui']?.def?.typeName === z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion
-
 export const isUndefinedSchema = (s: JSONSchema7): s is json.UndefinedSchema =>
   s.not === true && (s as json.UndefinedSchema)['x-zui']?.def?.typeName === z.ZodFirstPartyTypeKind.ZodUndefined
 

--- a/zui/src/transforms/json-schema-to-zui-next/index.test.ts
+++ b/zui/src/transforms/json-schema-to-zui-next/index.test.ts
@@ -182,26 +182,23 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
     assert(zSchema).toEqual(expected)
   })
 
-  test('should map DiscriminatedUnionSchema to ZodDiscriminatedUnion', () => {
-    const jSchema = buildSchema(
-      {
-        anyOf: [
-          {
-            type: 'object',
-            properties: { type: { type: 'string', const: 'A' }, a: { type: 'string' } },
-            required: ['type', 'a'],
-          },
-          {
-            type: 'object',
-            properties: { type: { type: 'string', const: 'B' }, b: { type: 'number' } },
-            required: ['type', 'b'],
-          },
-        ],
-      },
-      { def: { typeName: 'ZodDiscriminatedUnion', discriminator: 'type' } },
-    )
+  test('should map DiscriminatedUnionSchema to ZodUnion', () => {
+    const jSchema = buildSchema({
+      anyOf: [
+        {
+          type: 'object',
+          properties: { type: { type: 'string', const: 'A' }, a: { type: 'string' } },
+          required: ['type', 'a'],
+        },
+        {
+          type: 'object',
+          properties: { type: { type: 'string', const: 'B' }, b: { type: 'number' } },
+          required: ['type', 'b'],
+        },
+      ],
+    })
     const zSchema = fromJsonSchema(jSchema)
-    const expected = z.discriminatedUnion('type', [
+    const expected = z.union([
       z.object({ type: z.literal('A'), a: z.string() }),
       z.object({ type: z.literal('B'), b: z.number() }),
     ])

--- a/zui/src/transforms/json-schema-to-zui-next/index.ts
+++ b/zui/src/transforms/json-schema-to-zui-next/index.ts
@@ -157,15 +157,6 @@ function _fromJsonSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
       return _fromJsonSchema(schema.anyOf[0])
     }
 
-    if (guards.isDiscriminatedUnionSchema(schema)) {
-      const { discriminator } = schema['x-zui']?.def!
-      const options = schema.anyOf.map(_fromJsonSchema) as [
-        z.ZodDiscriminatedUnionOption<string>,
-        ...z.ZodDiscriminatedUnionOption<string>[],
-      ]
-      return z.discriminatedUnion(discriminator, options)
-    }
-
     if (guards.isOptionalSchema(schema)) {
       const inner = _fromJsonSchema(schema.anyOf[0])
       return inner.optional()

--- a/zui/src/transforms/transform-pipeline.test.ts
+++ b/zui/src/transforms/transform-pipeline.test.ts
@@ -379,13 +379,6 @@ describe.concurrent('transformPipeline', () => {
     const srcSchema = z.union([z.string(), z.number()])
     assert(srcSchema).toTransformBackToItself()
   })
-  it('should map ZodDiscriminatedUnion to itself', async () => {
-    const srcSchema = z.discriminatedUnion('type', [
-      z.object({ type: z.literal('foo'), foo: z.string() }),
-      z.object({ type: z.literal('bar'), bar: z.number() }),
-    ])
-    assert(srcSchema).toTransformBackToItself()
-  })
   it('should map ZodIntersection to itself', async () => {
     const srcSchema = z.intersection(
       z.object({ type: z.literal('foo'), foo: z.string() }),

--- a/zui/src/transforms/zui-to-json-schema-next/index.test.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/index.test.ts
@@ -166,7 +166,7 @@ describe('zuiToJsonSchemaNext', () => {
     })
   })
 
-  test('should map ZodDiscriminatedUnion to DiscriminatedUnionSchema', () => {
+  test('should map ZodDiscriminatedUnion to UnionSchema', () => {
     const schema = toJsonSchema(
       z.discriminatedUnion('type', [
         z.object({ type: z.literal('A'), a: z.string() }),
@@ -186,12 +186,6 @@ describe('zuiToJsonSchemaNext', () => {
           required: ['type', 'b'],
         },
       ],
-      'x-zui': {
-        def: {
-          typeName: 'ZodDiscriminatedUnion',
-          discriminator: 'type',
-        },
-      },
     })
   })
 

--- a/zui/src/transforms/zui-to-json-schema-next/index.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/index.ts
@@ -113,11 +113,8 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
       return {
         description: def.description,
         anyOf: def.options.map((option) => toJsonSchema(option)),
-        'x-zui': {
-          ...def['x-zui'],
-          def: { typeName: z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion, discriminator: def.discriminator },
-        },
-      } satisfies json.DiscriminatedUnionSchema
+        'x-zui': def['x-zui'],
+      } satisfies json.UnionSchema
 
     case z.ZodFirstPartyTypeKind.ZodIntersection:
       return {


### PR DESCRIPTION
I don't care about preserving the `z.discriminatedUnion()` when mapping to and from JSON Schema. There's no use case for it; both union and discriminated union have the exact same meaning. I prefer having a simpler logic. 