### PR TITLE
fix(zui): catchall inference

### DIFF
--- a/zui/package.json
+++ b/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/zui/src/z/types/object/index.ts
+++ b/zui/src/z/types/object/index.ts
@@ -1,4 +1,4 @@
-import { unique } from '../../utils'
+import { unique, ValueOf } from '../../utils'
 import {
   ZodArray,
   ZodEnum,
@@ -49,7 +49,8 @@ export type mergeTypes<A, B> = {
 export type objectOutputType<
   Shape extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
-> = UnknownKeysOutputType<UnknownKeys> & objectUtil.flatten<objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>>
+> = UnknownKeysOutputType<UnknownKeys, Shape> &
+  objectUtil.flatten<objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>>
 
 export type baseObjectOutputType<Shape extends ZodRawShape> = {
   [k in keyof Shape]: Shape[k]['_output']
@@ -58,19 +59,20 @@ export type baseObjectOutputType<Shape extends ZodRawShape> = {
 export type objectInputType<
   Shape extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
-> = objectUtil.flatten<baseObjectInputType<Shape>> & UnknownKeysInputType<UnknownKeys>
+> = objectUtil.flatten<baseObjectInputType<Shape>> & UnknownKeysInputType<UnknownKeys, Shape>
+
 export type baseObjectInputType<Shape extends ZodRawShape> = objectUtil.addQuestionMarks<{
   [k in keyof Shape]: Shape[k]['_input']
 }>
 
-export type UnknownKeysInputType<T extends UnknownKeysParam> = T extends ZodTypeAny
-  ? { [k: string]: unknown | T['_input'] } // T['_input'] alone doesn't work well because it swallows the known keys
+export type UnknownKeysInputType<T extends UnknownKeysParam, S extends ZodRawShape> = T extends ZodTypeAny
+  ? { [k: string]: T['_input'] | ValueOf<baseObjectInputType<S>> } // extra properties cannot contradict the main properties
   : T extends 'passthrough'
     ? { [k: string]: unknown }
     : {}
 
-export type UnknownKeysOutputType<T extends UnknownKeysParam> = T extends ZodTypeAny
-  ? { [k: string]: T['_output'] | unknown } // T['_output'] alone doesn't work well because it swallows the known keys
+export type UnknownKeysOutputType<T extends UnknownKeysParam, S extends ZodRawShape> = T extends ZodTypeAny
+  ? { [k: string]: T['_output'] | ValueOf<baseObjectOutputType<S>> } // extra properties cannot contradict the main properties
   : T extends 'passthrough'
     ? { [k: string]: unknown }
     : {}

--- a/zui/src/z/types/object/index.ts
+++ b/zui/src/z/types/object/index.ts
@@ -49,7 +49,7 @@ export type mergeTypes<A, B> = {
 export type objectOutputType<
   Shape extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
-> = objectUtil.flatten<objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>> & UnknownKeysOutputType<UnknownKeys>
+> = UnknownKeysOutputType<UnknownKeys> & objectUtil.flatten<objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>>
 
 export type baseObjectOutputType<Shape extends ZodRawShape> = {
   [k in keyof Shape]: Shape[k]['_output']
@@ -64,13 +64,13 @@ export type baseObjectInputType<Shape extends ZodRawShape> = objectUtil.addQuest
 }>
 
 export type UnknownKeysInputType<T extends UnknownKeysParam> = T extends ZodTypeAny
-  ? { [k: string]: T['_input'] }
+  ? { [k: string]: unknown | T['_input'] } // T['_input'] alone doesn't work well because it swallows the known keys
   : T extends 'passthrough'
     ? { [k: string]: unknown }
     : {}
 
 export type UnknownKeysOutputType<T extends UnknownKeysParam> = T extends ZodTypeAny
-  ? { [k: string]: T['_output'] }
+  ? { [k: string]: T['_output'] | unknown } // T['_output'] alone doesn't work well because it swallows the known keys
   : T extends 'passthrough'
     ? { [k: string]: unknown }
     : {}

--- a/zui/src/z/types/object/object.test.ts
+++ b/zui/src/z/types/object/object.test.ts
@@ -120,8 +120,11 @@ test('catchall inference', () => {
   fnInput({ first: 'asdf', num: 1243 })
   fnOutput({ first: 'asdf', num: 1243 })
 
-  util.assertEqual<unknown, (typeof d1)['asdf']>(true)
-  util.assertEqual<string, (typeof d1)['first']>(true)
+  const prop1 = d1.first
+  const prop2 = d1.num
+
+  util.assertEqual<string, typeof prop1>(true)
+  util.assertEqual<string | number | undefined, typeof prop2>(true)
 })
 
 test('catchall overrides strict', () => {

--- a/zui/src/z/types/object/object.test.ts
+++ b/zui/src/z/types/object/object.test.ts
@@ -113,7 +113,14 @@ test('catchall inference', () => {
     .catchall(z.number())
 
   const d1 = o1.parse({ first: 'asdf', num: 1243 })
-  util.assertEqual<number, (typeof d1)['asdf']>(true)
+
+  const fnInput = (input: z.input<typeof o1>) => {}
+  const fnOutput = (input: z.output<typeof o1>) => {}
+
+  fnInput({ first: 'asdf', num: 1243 })
+  fnOutput({ first: 'asdf', num: 1243 })
+
+  util.assertEqual<unknown, (typeof d1)['asdf']>(true)
   util.assertEqual<string, (typeof d1)['first']>(true)
 })
 

--- a/zui/src/z/utils.ts
+++ b/zui/src/z/utils.ts
@@ -1,3 +1,5 @@
+export type ValueOf<T> = T[keyof T]
+
 export const unique = <T>(arr: T[]): T[] => {
   return Array.from(new Set(arr))
 }


### PR DESCRIPTION
## Problem (before)

The problem with merging catchall types:

```ts
{
 [K: string]: CatchType
}
```

Is that this type swallows the object type, so all keys must be `CatchType`.

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/4ad2d4ea-6be1-4d7c-84e2-58476295df1d" />

## Solution

This is not a perfect solution, but I couldn't find better. "catch all" types are now unknown, but original types of known keys are preserved.