### PR TITLE
feat(zui): rename transformers

### DIFF
--- a/zui/src/index.ts
+++ b/zui/src/index.ts
@@ -1,23 +1,25 @@
-import { jsonSchemaToZui } from './transforms/json-schema-to-zui'
-import { zuiToJsonSchema } from './transforms/zui-to-json-schema'
-import { objectToZui } from './transforms/object-to-zui'
-import { toTypescript, TypescriptGenerationOptions } from './transforms/zui-to-typescript-type'
+import { jsonSchemaToZui as fromJsonSchemaLegacy } from './transforms/json-schema-to-zui'
+import { zuiToJsonSchema as toJsonSchemaLegacy } from './transforms/zui-to-json-schema'
+import { objectToZui as fromObject } from './transforms/object-to-zui'
+import { toTypescriptType, TypescriptGenerationOptions } from './transforms/zui-to-typescript-type'
 import { toTypescriptSchema } from './transforms/zui-to-typescript-schema'
-import { toJsonSchema as _experimentalToJsonSchemaNext } from './transforms/zui-to-json-schema-next'
-import { fromJsonSchema as _experimentalFromJsonSchemaNext } from './transforms/json-schema-to-zui-next'
+import { toJsonSchema } from './transforms/zui-to-json-schema-next'
+import { fromJsonSchema } from './transforms/json-schema-to-zui-next'
 import * as transformErrors from './transforms/common/errors'
 
 export * from './z'
 
 export const transforms = {
   errors: transformErrors,
-  jsonSchemaToZui,
-  zuiToJsonSchema,
-  objectToZui,
-  toTypescript,
+
+  fromJsonSchemaLegacy,
+  fromJsonSchema,
+  fromObject,
+
+  toJsonSchemaLegacy,
+  toJsonSchema,
+  toTypescriptType,
   toTypescriptSchema,
-  _experimentalToJsonSchemaNext,
-  _experimentalFromJsonSchemaNext,
 }
 
 export { type TypescriptGenerationOptions }

--- a/zui/src/index.ts
+++ b/zui/src/index.ts
@@ -1,6 +1,6 @@
 import { jsonSchemaToZui as fromJsonSchemaLegacy } from './transforms/json-schema-to-zui'
 import { zuiToJsonSchema as toJsonSchemaLegacy } from './transforms/zui-to-json-schema'
-import { objectToZui as fromObject } from './transforms/object-to-zui'
+import { fromObject } from './transforms/object-to-zui'
 import { toTypescriptType, TypescriptGenerationOptions } from './transforms/zui-to-typescript-type'
 import { toTypescriptSchema } from './transforms/zui-to-typescript-schema'
 import { toJsonSchema } from './transforms/zui-to-json-schema-next'

--- a/zui/src/transforms/json-schema-to-zui-next/index.ts
+++ b/zui/src/transforms/json-schema-to-zui-next/index.ts
@@ -9,9 +9,7 @@ import { ArraySchema, SetSchema, TupleSchema } from '../common/json-schema'
 const DEFAULT_TYPE = z.any()
 
 /**
- * # \#\#\# Experimental \#\#\#
- *
- * @experimental This function is experimental and is subject to breaking changes in the future.
+ * Converts a JSON Schema to a ZUI Schema.
  * @param schema json schema
  * @returns ZUI Schema
  */

--- a/zui/src/transforms/json-schema-to-zui/index.ts
+++ b/zui/src/transforms/json-schema-to-zui/index.ts
@@ -235,7 +235,12 @@ export const traverseZodDefinitions = (
   }
 }
 
-export const jsonSchemaToZui = (schema: JsonSchema7Type | any): ZodTypeAny => {
+/**
+ * Converts a JSONSchema to a Zui schema.
+ *
+ * @deprecated Use the new fromJsonSchema function instead.
+ */
+export const jsonSchemaToZui = (schema: JsonSchema7Type): ZodTypeAny => {
   const zodSchema = jsonSchemaToZod(schema)
   applyZuiPropsRecursively(zodSchema, schema)
   return zodSchema as unknown as ZodTypeAny

--- a/zui/src/transforms/json-schema-to-zui/json-schema-to-zui.test.ts
+++ b/zui/src/transforms/json-schema-to-zui/json-schema-to-zui.test.ts
@@ -148,7 +148,7 @@ describe('jsonSchemaToZui', () => {
   })
 })
 
-describe('Coercion deserialization', () => {
+describe.skip('Coercion deserialization', () => {
   it('should deserialize coerced strings correctly', () => {
     const schema = z.coerce.string().toJsonSchema()
     const asZui = jsonSchemaToZui(schema)

--- a/zui/src/transforms/json-schema-to-zui/json-schema-to-zui.test.ts
+++ b/zui/src/transforms/json-schema-to-zui/json-schema-to-zui.test.ts
@@ -148,33 +148,33 @@ describe('jsonSchemaToZui', () => {
   })
 })
 
-describe.skip('Coercion deserialization', () => {
+describe('Coercion deserialization', () => {
   it('should deserialize coerced strings correctly', () => {
-    const schema = z.coerce.string().toJsonSchema()
+    const schema = zuiToJsonSchema(z.coerce.string())
     const asZui = jsonSchemaToZui(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced numbers correctly', () => {
-    const schema = z.coerce.number().toJsonSchema()
+    const schema = zuiToJsonSchema(z.coerce.number())
     const asZui = jsonSchemaToZui(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced booleans correctly', () => {
-    const schema = z.coerce.boolean().toJsonSchema()
+    const schema = zuiToJsonSchema(z.coerce.boolean())
     const asZui = jsonSchemaToZui(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced dates correctly', () => {
-    const schema = z.coerce.date().toJsonSchema()
+    const schema = zuiToJsonSchema(z.coerce.date())
     const asZui = jsonSchemaToZui(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced bigints correctly', () => {
-    const schema = z.coerce.bigint().toJsonSchema()
+    const schema = zuiToJsonSchema(z.coerce.bigint())
     const asZui = jsonSchemaToZui(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })

--- a/zui/src/transforms/json-schema-to-zui/parsers/parseObject.test.ts
+++ b/zui/src/transforms/json-schema-to-zui/parsers/parseObject.test.ts
@@ -256,6 +256,7 @@ describe('parseObject', () => {
     )
   })
 
+  // TODO: this is error prone since the test now depends on the build artefact
   const run = (output: string, data: unknown) =>
     eval(`const {z} = require("@bpinternal/zui"); ${output}.safeParse(${JSON.stringify(data)})`)
 

--- a/zui/src/transforms/json-schema-to-zui/parsers/parseString.test.ts
+++ b/zui/src/transforms/json-schema-to-zui/parsers/parseString.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { parseString } from './parseString'
 
 describe('parseString', () => {
+  // TODO: this is error prone since the test now depends on the build artefact
   const run = (output: string, data: unknown) =>
     eval(
       `console.log(process.cwd()); const {z} = require("@bpinternal/zui"); ${output}.safeParse(${JSON.stringify(data)})`,

--- a/zui/src/transforms/object-to-zui/index.ts
+++ b/zui/src/transforms/object-to-zui/index.ts
@@ -7,7 +7,14 @@ const dateTimeRegex =
 
 export type ObjectToZuiOptions = { optional?: boolean; nullable?: boolean; passtrough?: boolean }
 
-export const objectToZui = (obj: object, opts?: ObjectToZuiOptions, isRoot = true): ZodTypeAny => {
+/**
+ * Converts a plain object to a Zod schema, by inferring the types of its properties.
+ *
+ * @param obj - The object to convert.
+ * @param opts - Options to customize the Zod schema:
+ * @returns A Zod schema representing the object.
+ */
+export const fromObject = (obj: object, opts?: ObjectToZuiOptions, isRoot = true): ZodTypeAny => {
   if (typeof obj !== 'object') {
     throw new errors.ObjectToZuiError('Input must be an object')
   }
@@ -45,12 +52,12 @@ export const objectToZui = (obj: object, opts?: ObjectToZuiOptions, isRoot = tru
             if (value.length === 0) {
               acc[key] = applyOptions(z.array(z.unknown()))
             } else if (typeof value[0] === 'object') {
-              acc[key] = applyOptions(z.array(objectToZui(value[0], opts, false)))
+              acc[key] = applyOptions(z.array(fromObject(value[0], opts, false)))
             } else if (['string', 'number', 'boolean'].includes(typeof value[0])) {
               acc[key] = applyOptions(z.array((z as any)[typeof value[0] as any]()))
             }
           } else {
-            acc[key] = applyOptions(objectToZui(value, opts, false))
+            acc[key] = applyOptions(fromObject(value, opts, false))
           }
           break
         default:

--- a/zui/src/transforms/zui-to-json-schema-next/index.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/index.ts
@@ -8,9 +8,7 @@ import { zodSetToJsonSet } from './type-processors/set'
 import { zodTupleToJsonTuple } from './type-processors/tuple'
 
 /**
- * # \#\#\# Experimental \#\#\#
- *
- * @experimental This function is experimental and is subject to breaking changes in the future.
+ * Converts a Zui schema to a ZUI flavored JSON schema.
  * @param schema zui schema
  * @returns ZUI flavored JSON schema
  */

--- a/zui/src/transforms/zui-to-json-schema/zui-extension.test.ts
+++ b/zui/src/transforms/zui-to-json-schema/zui-extension.test.ts
@@ -308,7 +308,8 @@ describe('zuiToJsonSchema', () => {
       }),
     )
 
-    expect(schema.toJsonSchema()).toEqual({
+    const zSchema = zuiToJsonSchema(schema)
+    expect(zSchema).toEqual({
       additionalProperties: false,
       properties: {
         type: {
@@ -391,7 +392,7 @@ describe('coercion serialization', () => {
   {
     it('serializes coerced dates correctly', () => {
       const schema = z.coerce.date().displayAs({ id: 'doood', params: {} } as never)
-      const serialized = schema.toJsonSchema()
+      const serialized = zuiToJsonSchema(schema)
       expect(serialized).toEqual({
         format: 'date-time',
         type: 'string',
@@ -404,7 +405,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced strings correctly', () => {
       const schema = z.coerce.string()
-      const serialized = schema.toJsonSchema()
+      const serialized = zuiToJsonSchema(schema)
       expect(serialized).toEqual({
         type: 'string',
         [zuiKey]: {
@@ -415,7 +416,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced bigints correctly', () => {
       const schema = z.coerce.bigint()
-      const serialized = schema.toJsonSchema()
+      const serialized = zuiToJsonSchema(schema)
       expect(serialized).toEqual({
         format: 'int64',
         type: 'integer',
@@ -427,7 +428,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced booleans correctly', () => {
       const schema = z.coerce.boolean()
-      const serialized = schema.toJsonSchema()
+      const serialized = zuiToJsonSchema(schema)
       expect(serialized).toEqual({
         type: 'boolean',
         [zuiKey]: {
@@ -438,7 +439,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced numbers correctly', () => {
       const schema = z.coerce.number()
-      const serialized = schema.toJsonSchema()
+      const serialized = zuiToJsonSchema(schema)
       expect(serialized).toEqual({
         type: 'number',
         [zuiKey]: {

--- a/zui/src/transforms/zui-to-json-schema/zui-extension.ts
+++ b/zui/src/transforms/zui-to-json-schema/zui-extension.ts
@@ -17,6 +17,11 @@ export type ZuiSchemaOptions = {
   target?: 'jsonSchema7' | 'openApi3'
 } & Partial<Pick<Options, 'unionStrategy' | 'discriminator'>>
 
+/**
+ * Converts a Zod schema to a JSON Schema.
+ *
+ * @deprecated Use the new toJsonSchema function instead.
+ */
 export const zuiToJsonSchema = (
   zuiType: z.ZodTypeAny,
   opts: ZuiSchemaOptions = { target: 'openApi3' },

--- a/zui/src/transforms/zui-to-typescript-type/index.test.ts
+++ b/zui/src/transforms/zui-to-typescript-type/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { toTypescript as toTs } from '.'
+import { toTypescriptType as toTs } from '.'
 import z, { ZodType } from '../../z'
 import * as errors from '../common/errors'
 

--- a/zui/src/transforms/zui-to-typescript-type/index.ts
+++ b/zui/src/transforms/zui-to-typescript-type/index.ts
@@ -78,15 +78,13 @@ type InternalOptions = {
   parent?: SchemaTypes
 }
 
-// TODO: rename this transform to `toTypescriptType`
-
 /**
  *
  * @param schema zui schema
  * @param options generation options
  * @returns a string of the TypeScript **type** representing the schema
  */
-export function toTypescript(schema: z.Schema, options: TypescriptGenerationOptions = {}): string {
+export function toTypescriptType(schema: z.Schema, options: TypescriptGenerationOptions = {}): string {
   const wrappedSchema: Declaration = getDeclarationProps(schema, options)
 
   let dts = sUnwrapZod(wrappedSchema, {})

--- a/zui/src/transforms/zui-to-typescript-type/primitives.test.ts
+++ b/zui/src/transforms/zui-to-typescript-type/primitives.test.ts
@@ -1,8 +1,8 @@
 import { test, expect } from 'vitest'
-import { toTypescript } from '.'
+import { toTypescriptType as toTs } from '.'
 import z from '../../z'
 
-const toTypescriptType = (schema: z.Schema) => toTypescript(schema, { declaration: 'variable' })
+const toTypescriptType = (schema: z.Schema) => toTs(schema, { declaration: 'variable' })
 
 test('string', async () => {
   const schema = z.string().title('x')

--- a/zui/src/z/types/basetype/index.ts
+++ b/zui/src/z/types/basetype/index.ts
@@ -42,13 +42,10 @@ import {
   ZodUnion,
 } from '../index'
 import { CatchFn } from '../catch'
-import { objectToZui, type ObjectToZuiOptions } from '../../../transforms/object-to-zui'
-import { TypescriptGenerationOptions, toTypescriptType } from '../../../transforms/zui-to-typescript-type'
+import { toTypescriptType, TypescriptGenerationOptions } from '../../../transforms/zui-to-typescript-type'
 import { toTypescriptSchema } from '../../../transforms/zui-to-typescript-schema'
-import { JSONSchema7 } from 'json-schema'
 import { toJsonSchema } from '../../../transforms/zui-to-json-schema-next'
 import { ZuiJsonSchema } from '../../../transforms/common/json-schema'
-import { fromJsonSchema } from '../../../transforms/json-schema-to-zui-next'
 
 /**
  * This type is not part of the original Zod library, it's been added in Zui to:
@@ -647,25 +644,6 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
    */
   toTypescriptSchema(): string {
     return toTypescriptSchema(this)
-  }
-
-  /**
-   * Converts a plain object to a Zui schema
-   * @param obj the object to convert
-   * @param opts options for the conversion
-   * @returns a Zui schema equivalent to the object
-   */
-  static fromObject(obj: object, opts?: ObjectToZuiOptions) {
-    return objectToZui(obj, opts)
-  }
-
-  /**
-   *
-   * @param schema JSON Schema to convert to a Zui schema
-   * @returns a Zui schema equivalent to the JSON Schema
-   */
-  static fromJsonSchema(schema: JSONSchema7) {
-    return fromJsonSchema(schema)
   }
 
   /**

--- a/zui/src/z/types/index.ts
+++ b/zui/src/z/types/index.ts
@@ -55,8 +55,4 @@ export * from './unknown'
 export * from './void'
 
 import defaultErrorMap from './error/locales/en'
-import { jsonSchemaToZui } from '../../transforms/json-schema-to-zui'
-import { objectToZui } from '../../transforms/object-to-zui'
-import { zuiToJsonSchema } from '../../transforms/zui-to-json-schema'
-
-export { defaultErrorMap, jsonSchemaToZui, objectToZui, zuiToJsonSchema }
+export { defaultErrorMap }

--- a/zui/src/z/z.ts
+++ b/zui/src/z/z.ts
@@ -139,8 +139,6 @@ const pipelineType = ZodPipeline.create
 const ostring = () => stringType().optional()
 const onumber = () => numberType().optional()
 const oboolean = () => booleanType().optional()
-const fromJsonSchema = ZodType.fromJsonSchema
-const fromObject = ZodType.fromObject
 
 export const coerce = {
   string: ((arg) => ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)['create'],
@@ -197,8 +195,6 @@ export {
   unionType as union,
   unknownType as unknown,
   voidType as void,
-  fromJsonSchema,
-  fromObject,
 }
 
 export const NEVER = INVALID as never


### PR DESCRIPTION
Previous `fromJsonSchema` and `toJsonSchema` transformers are now named with suffix legacy. What was previously prefixed with `experimental` is now the default behavior.