### PR TITLE
chore(zui): move some functions around + use same casing as zod v4

### DIFF
--- a/zui/src/index.ts
+++ b/zui/src/index.ts
@@ -1,25 +1,2 @@
-import { jsonSchemaToZui as fromJsonSchemaLegacy } from './transforms/json-schema-to-zui'
-import { zuiToJsonSchema as toJsonSchemaLegacy } from './transforms/zui-to-json-schema'
-import { fromObject } from './transforms/object-to-zui'
-import { toTypescriptType, TypescriptGenerationOptions } from './transforms/zui-to-typescript-type'
-import { toTypescriptSchema } from './transforms/zui-to-typescript-schema'
-import { toJsonSchema } from './transforms/zui-to-json-schema-next'
-import { fromJsonSchema } from './transforms/json-schema-to-zui-next'
-import * as transformErrors from './transforms/common/errors'
-
+export * from './transforms'
 export * from './z'
-
-export const transforms = {
-  errors: transformErrors,
-
-  fromJsonSchemaLegacy,
-  fromJsonSchema,
-  fromObject,
-
-  toJsonSchemaLegacy,
-  toJsonSchema,
-  toTypescriptType,
-  toTypescriptSchema,
-}
-
-export { type TypescriptGenerationOptions }

--- a/zui/src/transforms/common/errors.ts
+++ b/zui/src/transforms/common/errors.ts
@@ -18,7 +18,7 @@ export abstract class ZuiTransformError extends Error {
 }
 
 // json-schema-to-zui-error
-export class JsonSchemaToZuiError extends ZuiTransformError {
+export class JSONSchemaToZuiError extends ZuiTransformError {
   public constructor(message?: string) {
     super('json-schema-to-zui', message)
   }
@@ -32,12 +32,12 @@ export class ObjectToZuiError extends ZuiTransformError {
 }
 
 // zui-to-json-schema-error
-export class ZuiToJsonSchemaError extends ZuiTransformError {
+export class ZuiToJSONSchemaError extends ZuiTransformError {
   public constructor(message?: string) {
     super('zui-to-json-schema', message)
   }
 }
-export class UnsupportedZuiToJsonSchemaError extends ZuiToJsonSchemaError {
+export class UnsupportedZuiToJSONSchemaError extends ZuiToJSONSchemaError {
   public constructor(type: ZodFirstPartyTypeKind, { suggestedAlternative }: { suggestedAlternative?: string } = {}) {
     super(
       `Zod type ${type} cannot be transformed to JSON Schema.` +
@@ -45,16 +45,9 @@ export class UnsupportedZuiToJsonSchemaError extends ZuiToJsonSchemaError {
     )
   }
 }
-export class UnsupportedZuiCheckToJsonSchemaError extends ZuiToJsonSchemaError {
+export class UnsupportedZuiCheckToJSONSchemaError extends ZuiToJSONSchemaError {
   public constructor({ zodType, checkKind }: { zodType: ZodFirstPartyTypeKind; checkKind: string }) {
     super(`Zod check .${checkKind}() of type ${zodType} cannot be transformed to JSON Schema.`)
-  }
-}
-
-// json-schema-to-zui-error
-export class JSONSchemaToZuiError extends ZuiTransformError {
-  public constructor(message?: string) {
-    super('json-schema-to-zui', message)
   }
 }
 

--- a/zui/src/transforms/common/json-schema.ts
+++ b/zui/src/transforms/common/json-schema.ts
@@ -15,14 +15,14 @@ type UndefinedDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodUndefi
 type UnknownDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodUnknown }, Partial<z.ZodUnknownDef>>
 
 /**
- * ZuiJsonSchema:
+ * ZuiJSONSchema:
  *
  * A ZUI flavored subset of JSONSchema7
  */
 
 type ZuiExtension<Def extends Partial<z.ZodDef> = {}> = { def?: Def } & ZuiExtensionObject
 type JsonData = string | number | boolean | null | JsonData[] | { [key: string]: JsonData }
-type BaseZuiJsonSchema<Def extends Partial<z.ZodDef> = {}> = util.Satisfies<
+type BaseZuiJSONSchema<Def extends Partial<z.ZodDef> = {}> = util.Satisfies<
   {
     description?: string
     readOnly?: boolean
@@ -34,12 +34,12 @@ type BaseZuiJsonSchema<Def extends Partial<z.ZodDef> = {}> = util.Satisfies<
 
 // From the JSON Schema spec: "Format is not limited to a specific set of valid values or types. Users may define their own custom keywords"
 type _ZodSpecificStringFormat = 'cuid' | 'cuid2' | 'emoji' | 'ulid'
-type _JsonSchemaStringFormat = 'date-time' | 'email' | 'ipv4' | 'ipv6' | 'uri' | 'uuid'
+type _JSONSchemaStringFormat = 'date-time' | 'email' | 'ipv4' | 'ipv6' | 'uri' | 'uuid'
 type _StringSchema = util.Satisfies<
   {
     type: 'string'
     pattern?: string
-    format?: _JsonSchemaStringFormat | _ZodSpecificStringFormat
+    format?: _JSONSchemaStringFormat | _ZodSpecificStringFormat
     minLength?: number
     maxLength?: number
   },
@@ -63,14 +63,14 @@ type _NullSchema = util.Satisfies<{ type: 'null' }, JSONSchema7>
 type _UndefinedSchema = util.Satisfies<{ not: true }, JSONSchema7>
 type _NeverSchema = util.Satisfies<{ not: true }, JSONSchema7>
 type _ArraySchema = util.Satisfies<
-  { type: 'array'; items: ZuiJsonSchema; minItems?: number; maxItems?: number },
+  { type: 'array'; items: ZuiJSONSchema; minItems?: number; maxItems?: number },
   JSONSchema7
 >
-type _UnionSchema = util.Satisfies<{ anyOf: ZuiJsonSchema[] }, JSONSchema7>
-type _DiscriminatedUnionSchema = util.Satisfies<{ anyOf: ZuiJsonSchema[] }, JSONSchema7>
-type _IntersectionSchema = util.Satisfies<{ allOf: ZuiJsonSchema[] }, JSONSchema7>
+type _UnionSchema = util.Satisfies<{ anyOf: ZuiJSONSchema[] }, JSONSchema7>
+type _DiscriminatedUnionSchema = util.Satisfies<{ anyOf: ZuiJSONSchema[] }, JSONSchema7>
+type _IntersectionSchema = util.Satisfies<{ allOf: ZuiJSONSchema[] }, JSONSchema7>
 type _SetSchema = util.Satisfies<
-  { type: 'array'; items: ZuiJsonSchema; uniqueItems: true; minItems?: number; maxItems?: number },
+  { type: 'array'; items: ZuiJSONSchema; uniqueItems: true; minItems?: number; maxItems?: number },
   JSONSchema7
 >
 type _EnumSchema = util.Satisfies<{ type: 'string'; enum: string[] }, JSONSchema7>
@@ -78,50 +78,50 @@ type _RefSchema = util.Satisfies<{ $ref: string }, JSONSchema7>
 type _ObjectSchema = util.Satisfies<
   {
     type: 'object'
-    properties: { [key: string]: ZuiJsonSchema }
-    additionalProperties?: ZuiJsonSchema | boolean
+    properties: { [key: string]: ZuiJSONSchema }
+    additionalProperties?: ZuiJSONSchema | boolean
     required?: string[]
   },
   JSONSchema7
 >
 type _TupleSchema = util.Satisfies<
-  { type: 'array'; items: ZuiJsonSchema[]; additionalItems?: ZuiJsonSchema },
+  { type: 'array'; items: ZuiJSONSchema[]; additionalItems?: ZuiJSONSchema },
   JSONSchema7
 >
-type _RecordSchema = util.Satisfies<{ type: 'object'; additionalProperties: ZuiJsonSchema }, JSONSchema7>
+type _RecordSchema = util.Satisfies<{ type: 'object'; additionalProperties: ZuiJSONSchema }, JSONSchema7>
 type _LiteralStringSchema = util.Satisfies<{ type: 'string'; const: string }, JSONSchema7>
 type _LiteralNumberSchema = util.Satisfies<{ type: 'number'; const: number }, JSONSchema7>
 type _LiteralBooleanSchema = util.Satisfies<{ type: 'boolean'; const: boolean }, JSONSchema7>
-type _OptionalSchema = util.Satisfies<{ anyOf: [ZuiJsonSchema, UndefinedSchema] }, JSONSchema7>
-type _NullableSchema = util.Satisfies<{ anyOf: [ZuiJsonSchema, NullSchema] }, JSONSchema7>
+type _OptionalSchema = util.Satisfies<{ anyOf: [ZuiJSONSchema, UndefinedSchema] }, JSONSchema7>
+type _NullableSchema = util.Satisfies<{ anyOf: [ZuiJSONSchema, NullSchema] }, JSONSchema7>
 
-export type StringSchema = _StringSchema & BaseZuiJsonSchema
-export type NumberSchema = _NumberSchema & BaseZuiJsonSchema
-export type BooleanSchema = _BooleanSchema & BaseZuiJsonSchema
-export type NullSchema = _NullSchema & BaseZuiJsonSchema
-export type UndefinedSchema = _UndefinedSchema & BaseZuiJsonSchema<UndefinedDef>
-export type NeverSchema = _NeverSchema & BaseZuiJsonSchema
-export type AnySchema = BaseZuiJsonSchema
-export type UnknownSchema = BaseZuiJsonSchema<UnknownDef>
-export type ArraySchema = _ArraySchema & BaseZuiJsonSchema
-export type UnionSchema = _UnionSchema & BaseZuiJsonSchema
-export type DiscriminatedUnionSchema = _DiscriminatedUnionSchema & BaseZuiJsonSchema
-export type IntersectionSchema = _IntersectionSchema & BaseZuiJsonSchema
-export type SetSchema = _SetSchema & BaseZuiJsonSchema
-export type EnumSchema = _EnumSchema & BaseZuiJsonSchema
-export type RefSchema = _RefSchema & BaseZuiJsonSchema
-export type ObjectSchema = _ObjectSchema & BaseZuiJsonSchema
-export type TupleSchema = _TupleSchema & BaseZuiJsonSchema
-export type RecordSchema = _RecordSchema & BaseZuiJsonSchema
-export type LiteralStringSchema = _LiteralStringSchema & BaseZuiJsonSchema
-export type LiteralNumberSchema = _LiteralNumberSchema & BaseZuiJsonSchema
-export type LiteralBooleanSchema = _LiteralBooleanSchema & BaseZuiJsonSchema
-export type OptionalSchema = _OptionalSchema & BaseZuiJsonSchema<OptionalDef>
-export type NullableSchema = _NullableSchema & BaseZuiJsonSchema<NullableDef>
+export type StringSchema = _StringSchema & BaseZuiJSONSchema
+export type NumberSchema = _NumberSchema & BaseZuiJSONSchema
+export type BooleanSchema = _BooleanSchema & BaseZuiJSONSchema
+export type NullSchema = _NullSchema & BaseZuiJSONSchema
+export type UndefinedSchema = _UndefinedSchema & BaseZuiJSONSchema<UndefinedDef>
+export type NeverSchema = _NeverSchema & BaseZuiJSONSchema
+export type AnySchema = BaseZuiJSONSchema
+export type UnknownSchema = BaseZuiJSONSchema<UnknownDef>
+export type ArraySchema = _ArraySchema & BaseZuiJSONSchema
+export type UnionSchema = _UnionSchema & BaseZuiJSONSchema
+export type DiscriminatedUnionSchema = _DiscriminatedUnionSchema & BaseZuiJSONSchema
+export type IntersectionSchema = _IntersectionSchema & BaseZuiJSONSchema
+export type SetSchema = _SetSchema & BaseZuiJSONSchema
+export type EnumSchema = _EnumSchema & BaseZuiJSONSchema
+export type RefSchema = _RefSchema & BaseZuiJSONSchema
+export type ObjectSchema = _ObjectSchema & BaseZuiJSONSchema
+export type TupleSchema = _TupleSchema & BaseZuiJSONSchema
+export type RecordSchema = _RecordSchema & BaseZuiJSONSchema
+export type LiteralStringSchema = _LiteralStringSchema & BaseZuiJSONSchema
+export type LiteralNumberSchema = _LiteralNumberSchema & BaseZuiJSONSchema
+export type LiteralBooleanSchema = _LiteralBooleanSchema & BaseZuiJSONSchema
+export type OptionalSchema = _OptionalSchema & BaseZuiJSONSchema<OptionalDef>
+export type NullableSchema = _NullableSchema & BaseZuiJSONSchema<NullableDef>
 
 export type LiteralSchema = LiteralStringSchema | LiteralNumberSchema | LiteralBooleanSchema
 
-export type ZuiJsonSchema =
+export type ZuiJSONSchema =
   | StringSchema
   | NumberSchema
   | BooleanSchema

--- a/zui/src/transforms/index.ts
+++ b/zui/src/transforms/index.ts
@@ -1,9 +1,9 @@
-export { fromJsonSchemaLegacy } from './json-schema-to-zui'
-export { fromJsonSchema } from './json-schema-to-zui-next'
+export { fromJSONSchemaLegacy } from './json-schema-to-zui'
+export { fromJSONSchema } from './json-schema-to-zui-next'
 export { fromObject } from './object-to-zui'
 
-export { toJsonSchemaLegacy } from './zui-to-json-schema'
-export { toJsonSchema } from './zui-to-json-schema-next'
+export { toJSONSchemaLegacy } from './zui-to-json-schema'
+export { toJSONSchema } from './zui-to-json-schema-next'
 export { toTypescriptType, type TypescriptGenerationOptions } from './zui-to-typescript-type'
 export { toTypescriptSchema } from './zui-to-typescript-schema'
 

--- a/zui/src/transforms/index.ts
+++ b/zui/src/transforms/index.ts
@@ -1,0 +1,10 @@
+export { fromJsonSchemaLegacy } from './json-schema-to-zui'
+export { fromJsonSchema } from './json-schema-to-zui-next'
+export { fromObject } from './object-to-zui'
+
+export { toJsonSchemaLegacy } from './zui-to-json-schema'
+export { toJsonSchema } from './zui-to-json-schema-next'
+export { toTypescriptType, type TypescriptGenerationOptions } from './zui-to-typescript-type'
+export { toTypescriptSchema } from './zui-to-typescript-schema'
+
+export * as errors from './common/errors'

--- a/zui/src/transforms/json-schema-to-zui-next/index.test.ts
+++ b/zui/src/transforms/json-schema-to-zui-next/index.test.ts
@@ -1,17 +1,17 @@
 import z from '../../z'
 import { describe, test, expect } from 'vitest'
-import { fromJsonSchema } from './index'
+import { fromJSONSchema } from './index'
 import { JSONSchema7 } from 'json-schema'
-import { ZuiJsonSchema } from '../common/json-schema'
+import { ZuiJSONSchema } from '../common/json-schema'
 
-const buildSchema = (s: JSONSchema7, xZui: ZuiJsonSchema['x-zui'] = undefined): JSONSchema7 => {
+const buildSchema = (s: JSONSchema7, xZui: ZuiJSONSchema['x-zui'] = undefined): JSONSchema7 => {
   return { ...s, 'x-zui': xZui } as JSONSchema7
 }
 
-const undefinedSchema = (xZui?: ZuiJsonSchema['x-zui']): JSONSchema7 =>
+const undefinedSchema = (xZui?: ZuiJSONSchema['x-zui']): JSONSchema7 =>
   buildSchema({ not: true }, { ...xZui, def: { typeName: z.ZodFirstPartyTypeKind.ZodUndefined } })
 
-const nullSchema = (xZui?: ZuiJsonSchema['x-zui']): JSONSchema7 => buildSchema({ type: 'null' }, xZui)
+const nullSchema = (xZui?: ZuiJSONSchema['x-zui']): JSONSchema7 => buildSchema({ type: 'null' }, xZui)
 
 const assert = (actual: z.Schema) => ({
   toEqual: (expected: z.Schema) => {
@@ -24,59 +24,59 @@ const assert = (actual: z.Schema) => ({
   },
 })
 
-describe.concurrent('zuifromJsonSchemaNext', () => {
+describe.concurrent('zuifromJSONSchemaNext', () => {
   test('should map StringSchema to ZodString', () => {
     const jSchema = buildSchema({ type: 'string' })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.string()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map NumberSchema to ZodNumber', () => {
     const jSchema = buildSchema({ type: 'number' })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.number()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map BooleanSchema to ZodBoolean', () => {
     const jSchema = buildSchema({ type: 'boolean' })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.boolean()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map UndefinedSchema to ZodUndefined', () => {
     const jSchema = buildSchema({ not: true }, { def: { typeName: 'ZodUndefined' } })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.undefined()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map NullSchema to ZodNull', () => {
     const jSchema = buildSchema({ type: 'null' }, { def: { typeName: 'ZodNull' } })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.null()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map AnySchema to ZodAny', () => {
     const jSchema = buildSchema({})
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.any()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map UnknownSchema to ZodUnknown', () => {
     const jSchema = buildSchema({}, { def: { typeName: 'ZodUnknown' } })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.unknown()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map NeverSchema to ZodNever', () => {
     const jSchema = buildSchema({ not: true })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.never()
     assert(zSchema).toEqual(expected)
   })
@@ -84,28 +84,28 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
   describe.concurrent('ArraySchema', () => {
     test('should map ArraySchema to ZodArray', () => {
       const jSchema = buildSchema({ type: 'array', items: { type: 'string' } })
-      const zSchema = fromJsonSchema(jSchema)
+      const zSchema = fromJSONSchema(jSchema)
       const expected = z.array(z.string())
       assert(zSchema).toEqual(expected)
     })
 
     test('should map ArraySchema with min to ZodArray', () => {
       const jSchema = buildSchema({ type: 'array', items: { type: 'string' }, minItems: 4 })
-      const zSchema = fromJsonSchema(jSchema)
+      const zSchema = fromJSONSchema(jSchema)
       const expected = z.array(z.string()).min(4)
       assert(zSchema).toEqual(expected)
     })
 
     test('should map ArraySchema with min and max to ZodArray', () => {
       const jSchema = buildSchema({ type: 'array', items: { type: 'string' }, minItems: 4, maxItems: 8 })
-      const zSchema = fromJsonSchema(jSchema)
+      const zSchema = fromJSONSchema(jSchema)
       const expected = z.array(z.string()).min(4).max(8)
       assert(zSchema).toEqual(expected)
     })
 
     test('should map ArraySchema with exact size to ZodArray', () => {
       const jSchema = buildSchema({ type: 'array', items: { type: 'string' }, minItems: 4, maxItems: 4 })
-      const zSchema = fromJsonSchema(jSchema)
+      const zSchema = fromJSONSchema(jSchema)
       const expected = z.array(z.string()).length(4)
       assert(zSchema).toEqual(expected)
     })
@@ -113,7 +113,7 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
 
   test('should map ObjectSchema to ZodObject', () => {
     const jSchema = buildSchema({ type: 'object', properties: { name: { type: 'string' } }, required: ['name'] })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.object({ name: z.string() })
     assert(zSchema).toEqual(expected)
   })
@@ -130,7 +130,7 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
       },
       required: ['name'],
     })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.object({
       name: z.string(),
       age: z.number().optional(),
@@ -146,7 +146,7 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
       required: ['name'],
       additionalProperties: { type: 'number' },
     })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.object({ name: z.string() }).catchall(z.number())
     assert(zSchema).toEqual(expected)
   })
@@ -158,7 +158,7 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
       required: ['name'],
       additionalProperties: true,
     })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.object({ name: z.string() }).passthrough()
     assert(zSchema).toEqual(expected)
   })
@@ -170,14 +170,14 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
       required: ['name'],
       additionalProperties: false,
     })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.object({ name: z.string() }).strict()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map UnionSchema to ZodUnion', () => {
     const jSchema = buildSchema({ anyOf: [{ type: 'string' }, { type: 'number' }] })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.union([z.string(), z.number()])
     assert(zSchema).toEqual(expected)
   })
@@ -197,7 +197,7 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
         },
       ],
     })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.union([
       z.object({ type: z.literal('A'), a: z.string() }),
       z.object({ type: z.literal('B'), b: z.number() }),
@@ -212,21 +212,21 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
         { type: 'object', properties: { b: { type: 'number' } }, required: ['b'] },
       ],
     })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() }))
     assert(zSchema).toEqual(expected)
   })
 
   test('should map TupleSchema to ZodTuple', () => {
     const jSchema = buildSchema({ type: 'array', items: [{ type: 'string' }, { type: 'number' }] })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.tuple([z.string(), z.number()])
     assert(zSchema).toEqual(expected)
   })
 
   test('should map RecordSchema to ZodRecord', () => {
     const jSchema = buildSchema({ type: 'object', additionalProperties: { type: 'number' } })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.record(z.number())
     assert(zSchema).toEqual(expected)
   })
@@ -234,14 +234,14 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
   describe.concurrent('SetSchema', () => {
     test('should map SetSchema to ZodSet', () => {
       const jSchema = buildSchema({ type: 'array', items: { type: 'string' }, uniqueItems: true })
-      const zSchema = fromJsonSchema(jSchema)
+      const zSchema = fromJSONSchema(jSchema)
       const expected = z.set(z.string())
       assert(zSchema).toEqual(expected)
     })
 
     test('should map SetSchema with min to ZodSet', () => {
       const jSchema = buildSchema({ type: 'array', items: { type: 'string' }, uniqueItems: true, minItems: 4 })
-      const zSchema = fromJsonSchema(jSchema)
+      const zSchema = fromJSONSchema(jSchema)
       const expected = z.set(z.string()).min(4)
       assert(zSchema).toEqual(expected)
     })
@@ -254,7 +254,7 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
         minItems: 4,
         maxItems: 8,
       })
-      const zSchema = fromJsonSchema(jSchema)
+      const zSchema = fromJSONSchema(jSchema)
       const expected = z.set(z.string()).min(4).max(8)
       assert(zSchema).toEqual(expected)
     })
@@ -262,28 +262,28 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
 
   test('should map LiteralStringSchema to ZodLiteral', () => {
     const jSchema = buildSchema({ type: 'string', const: 'a' })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.literal('a')
     assert(zSchema).toEqual(expected)
   })
 
   test('should map LiteralNumberSchema to ZodLiteral', () => {
     const jSchema = buildSchema({ type: 'number', const: 1 })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.literal(1)
     assert(zSchema).toEqual(expected)
   })
 
   test('should map LiteralBooleanSchema to ZodLiteral', () => {
     const jSchema = buildSchema({ type: 'boolean', const: true })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.literal(true)
     assert(zSchema).toEqual(expected)
   })
 
   test('should map EnumSchema to ZodEnum', () => {
     const jSchema = buildSchema({ type: 'string', enum: ['a', 'b'] })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.enum(['a', 'b'])
     assert(zSchema).toEqual(expected)
   })
@@ -293,35 +293,35 @@ describe.concurrent('zuifromJsonSchemaNext', () => {
       { anyOf: [{ type: 'string' }, undefinedSchema()] },
       { def: { typeName: 'ZodOptional' } },
     )
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.string().optional()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map NullableSchema to ZodNullable', () => {
     const jSchema = buildSchema({ anyOf: [{ type: 'string' }, nullSchema()] }, { def: { typeName: 'ZodNullable' } })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.string().nullable()
     assert(zSchema).toEqual(expected)
   })
 
-  test('should map ZuiJsonSchema to ZodDefault if it contains default anotation', () => {
+  test('should map ZuiJSONSchema to ZodDefault if it contains default anotation', () => {
     const jSchema = buildSchema({ type: 'string', default: 'hello' })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.string().default('hello')
     assert(zSchema).toEqual(expected)
   })
 
-  test('should map ZuiJsonSchema to ZodReadonly if it contains readOnly anotation', () => {
+  test('should map ZuiJSONSchema to ZodReadonly if it contains readOnly anotation', () => {
     const jSchema = buildSchema({ type: 'string', readOnly: true })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.string().readonly()
     assert(zSchema).toEqual(expected)
   })
 
   test('should map RefSchema to ZodRef', () => {
     const jSchema = buildSchema({ $ref: 'foo' })
-    const zSchema = fromJsonSchema(jSchema)
+    const zSchema = fromJSONSchema(jSchema)
     const expected = z.ref('foo')
     assert(zSchema).toEqual(expected)
   })

--- a/zui/src/transforms/json-schema-to-zui-next/index.ts
+++ b/zui/src/transforms/json-schema-to-zui-next/index.ts
@@ -13,11 +13,11 @@ const DEFAULT_TYPE = z.any()
  * @param schema json schema
  * @returns ZUI Schema
  */
-export function fromJsonSchema(schema: JSONSchema7): z.ZodType {
-  return _fromJsonSchema(schema)
+export function fromJSONSchema(schema: JSONSchema7): z.ZodType {
+  return _fromJSONSchema(schema)
 }
 
-function _fromJsonSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
+function _fromJSONSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
   if (schema === undefined) {
     return DEFAULT_TYPE
   }
@@ -31,11 +31,11 @@ function _fromJsonSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
   }
 
   if (schema.default !== undefined) {
-    const inner = _fromJsonSchema({ ...schema, default: undefined })
+    const inner = _fromJSONSchema({ ...schema, default: undefined })
     return inner.default(schema.default)
   }
   if (schema.readOnly) {
-    const inner = _fromJsonSchema({ ...schema, readOnly: undefined })
+    const inner = _fromJSONSchema({ ...schema, readOnly: undefined })
     return inner.readonly()
   }
 
@@ -83,10 +83,10 @@ function _fromJsonSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
       return DEFAULT_TYPE
     }
     if (schema.type.length === 1) {
-      return _fromJsonSchema({ ...schema, type: schema.type[0] })
+      return _fromJSONSchema({ ...schema, type: schema.type[0] })
     }
     const { type: _, ...tmp } = schema
-    const types = schema.type.map((t) => _fromJsonSchema({ ...tmp, type: t })) as [z.ZodType, z.ZodType, ...z.ZodType[]]
+    const types = schema.type.map((t) => _fromJSONSchema({ ...tmp, type: t })) as [z.ZodType, z.ZodType, ...z.ZodType[]]
     return z.union(types)
   }
 
@@ -119,20 +119,20 @@ function _fromJsonSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
   }
 
   if (schema.type === 'array') {
-    return arrayJSONSchemaToZuiArray(schema as ArraySchema | TupleSchema | SetSchema, _fromJsonSchema)
+    return arrayJSONSchemaToZuiArray(schema as ArraySchema | TupleSchema | SetSchema, _fromJSONSchema)
   }
 
   if (schema.type === 'object') {
     if (schema.additionalProperties !== undefined && schema.properties !== undefined) {
-      const catchAll = _fromJsonSchema(schema.additionalProperties)
-      const inner = _fromJsonSchema({ ...schema, additionalProperties: undefined }) as z.ZodObject
+      const catchAll = _fromJSONSchema(schema.additionalProperties)
+      const inner = _fromJSONSchema({ ...schema, additionalProperties: undefined }) as z.ZodObject
       return inner.catchall(catchAll)
     }
 
     if (schema.properties !== undefined) {
       const properties: Record<string, z.ZodType> = {}
       for (const [key, value] of Object.entries(schema.properties)) {
-        const mapped: z.ZodType = _fromJsonSchema(value)
+        const mapped: z.ZodType = _fromJSONSchema(value)
         const required: string[] = schema.required ?? []
         properties[key] = required.includes(key) ? mapped : mapped.optional()
       }
@@ -140,7 +140,7 @@ function _fromJsonSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
     }
 
     if (schema.additionalProperties !== undefined) {
-      const inner = _fromJsonSchema(schema.additionalProperties)
+      const inner = _fromJSONSchema(schema.additionalProperties)
       return z.record(inner)
     }
 
@@ -152,20 +152,20 @@ function _fromJsonSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
       return DEFAULT_TYPE
     }
     if (schema.anyOf.length === 1) {
-      return _fromJsonSchema(schema.anyOf[0])
+      return _fromJSONSchema(schema.anyOf[0])
     }
 
     if (guards.isOptionalSchema(schema)) {
-      const inner = _fromJsonSchema(schema.anyOf[0])
+      const inner = _fromJSONSchema(schema.anyOf[0])
       return inner.optional()
     }
 
     if (guards.isNullableSchema(schema)) {
-      const inner = _fromJsonSchema(schema.anyOf[0])
+      const inner = _fromJSONSchema(schema.anyOf[0])
       return inner.nullable()
     }
 
-    const options = schema.anyOf.map(_fromJsonSchema) as [z.ZodType, z.ZodType, ...z.ZodType[]]
+    const options = schema.anyOf.map(_fromJSONSchema) as [z.ZodType, z.ZodType, ...z.ZodType[]]
     return z.union(options)
   }
 
@@ -174,11 +174,11 @@ function _fromJsonSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
       return DEFAULT_TYPE
     }
     if (schema.allOf.length === 1) {
-      return _fromJsonSchema(schema.allOf[0])
+      return _fromJSONSchema(schema.allOf[0])
     }
     const [left, ...right] = schema.allOf as [JSONSchema7, ...JSONSchema7[]]
-    const zLeft = _fromJsonSchema(left)
-    const zRight = _fromJsonSchema({ allOf: right })
+    const zLeft = _fromJSONSchema(left)
+    const zRight = _fromJSONSchema({ allOf: right })
     return z.intersection(zLeft, zRight)
   }
 

--- a/zui/src/transforms/json-schema-to-zui/index.ts
+++ b/zui/src/transforms/json-schema-to-zui/index.ts
@@ -240,7 +240,7 @@ export const traverseZodDefinitions = (
  *
  * @deprecated Use the new fromJsonSchema function instead.
  */
-export const jsonSchemaToZui = (schema: JsonSchema7Type): ZodTypeAny => {
+export const fromJsonSchemaLegacy = (schema: JsonSchema7Type): ZodTypeAny => {
   const zodSchema = jsonSchemaToZod(schema)
   applyZuiPropsRecursively(zodSchema, schema)
   return zodSchema as unknown as ZodTypeAny

--- a/zui/src/transforms/json-schema-to-zui/index.ts
+++ b/zui/src/transforms/json-schema-to-zui/index.ts
@@ -39,7 +39,7 @@ const jsonSchemaToZod = (schema: any): ZodTypeAny => {
   code = code.replaceAll('errors: z.ZodError[]', 'errors')
   const evaluationResult = evalZuiString(code)
   if (!evaluationResult.sucess) {
-    throw new errors.JsonSchemaToZuiError(evaluationResult.error)
+    throw new errors.JSONSchemaToZuiError(evaluationResult.error)
   }
   return evaluationResult.value
 }
@@ -231,16 +231,16 @@ export const traverseZodDefinitions = (
       cb(ZodFirstPartyTypeKind.ZodDefault, def, path)
       break
     default:
-      throw new errors.JsonSchemaToZuiError(`Unknown Zod type: ${(def as any).typeName}`)
+      throw new errors.JSONSchemaToZuiError(`Unknown Zod type: ${(def as any).typeName}`)
   }
 }
 
 /**
  * Converts a JSONSchema to a Zui schema.
  *
- * @deprecated Use the new fromJsonSchema function instead.
+ * @deprecated Use the new fromJSONSchema function instead.
  */
-export const fromJsonSchemaLegacy = (schema: JsonSchema7Type): ZodTypeAny => {
+export const fromJSONSchemaLegacy = (schema: JsonSchema7Type): ZodTypeAny => {
   const zodSchema = jsonSchemaToZod(schema)
   applyZuiPropsRecursively(zodSchema, schema)
   return zodSchema as unknown as ZodTypeAny

--- a/zui/src/transforms/json-schema-to-zui/json-schema-to-zui.test.ts
+++ b/zui/src/transforms/json-schema-to-zui/json-schema-to-zui.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test, it } from 'vitest'
 import { ZodTypeAny, z } from '../../z/index'
 import { zuiKey } from '../../ui/constants'
-import { jsonSchemaToZodStr, fromJsonSchemaLegacy, traverseZodDefinitions } from '.'
-import { toJsonSchemaLegacy } from '../zui-to-json-schema/zui-extension'
+import { jsonSchemaToZodStr, fromJSONSchemaLegacy, traverseZodDefinitions } from '.'
+import { toJSONSchemaLegacy } from '../zui-to-json-schema/zui-extension'
 import { JSONSchema7 } from 'json-schema'
 
 const testZuiConversion = (zuiObject: ZodTypeAny) => {
-  const jsonSchema = toJsonSchemaLegacy(zuiObject)
-  const asZui = fromJsonSchemaLegacy(jsonSchema)
-  const convertedJsonSchema = toJsonSchemaLegacy(asZui)
+  const jsonSchema = toJSONSchemaLegacy(zuiObject)
+  const asZui = fromJSONSchemaLegacy(jsonSchema)
+  const convertedJsonSchema = toJSONSchemaLegacy(asZui)
 
   expect(jsonSchema).toEqual(convertedJsonSchema)
 
@@ -30,7 +30,7 @@ describe('jsonSchemaToZui', () => {
   test('convert record', () => {
     const inner = [z.string().title('Name'), z.number().title('Age')] as const
 
-    expect(toJsonSchemaLegacy(z.record(inner[0], inner[1]))).toMatchObject({
+    expect(toJSONSchemaLegacy(z.record(inner[0], inner[1]))).toMatchObject({
       type: 'object',
       additionalProperties: {
         type: 'number',
@@ -91,14 +91,14 @@ describe('jsonSchemaToZui', () => {
     ])
     const strategy = { discriminator: true, unionStrategy: 'oneOf' } as const
 
-    const jsonSchema = toJsonSchemaLegacy(zuiSchema, strategy)
-    const converted = toJsonSchemaLegacy(fromJsonSchemaLegacy(jsonSchema), strategy)
+    const jsonSchema = toJSONSchemaLegacy(zuiSchema, strategy)
+    const converted = toJSONSchemaLegacy(fromJSONSchemaLegacy(jsonSchema), strategy)
 
     expect(jsonSchema).toEqual(converted)
   })
 
   test('convert object with nested', () => {
-    const zuiSchema = fromJsonSchemaLegacy({
+    const zuiSchema = fromJSONSchemaLegacy({
       type: 'object',
       properties: {
         name: { type: 'string', description: 'Name of person', [zuiKey]: { title: 'title' } },
@@ -150,32 +150,32 @@ describe('jsonSchemaToZui', () => {
 
 describe('Coercion deserialization', () => {
   it('should deserialize coerced strings correctly', () => {
-    const schema = toJsonSchemaLegacy(z.coerce.string())
-    const asZui = fromJsonSchemaLegacy(schema)
+    const schema = toJSONSchemaLegacy(z.coerce.string())
+    const asZui = fromJSONSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced numbers correctly', () => {
-    const schema = toJsonSchemaLegacy(z.coerce.number())
-    const asZui = fromJsonSchemaLegacy(schema)
+    const schema = toJSONSchemaLegacy(z.coerce.number())
+    const asZui = fromJSONSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced booleans correctly', () => {
-    const schema = toJsonSchemaLegacy(z.coerce.boolean())
-    const asZui = fromJsonSchemaLegacy(schema)
+    const schema = toJSONSchemaLegacy(z.coerce.boolean())
+    const asZui = fromJSONSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced dates correctly', () => {
-    const schema = toJsonSchemaLegacy(z.coerce.date())
-    const asZui = fromJsonSchemaLegacy(schema)
+    const schema = toJSONSchemaLegacy(z.coerce.date())
+    const asZui = fromJSONSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced bigints correctly', () => {
-    const schema = toJsonSchemaLegacy(z.coerce.bigint())
-    const asZui = fromJsonSchemaLegacy(schema)
+    const schema = toJSONSchemaLegacy(z.coerce.bigint())
+    const asZui = fromJSONSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 

--- a/zui/src/transforms/json-schema-to-zui/json-schema-to-zui.test.ts
+++ b/zui/src/transforms/json-schema-to-zui/json-schema-to-zui.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test, it } from 'vitest'
 import { ZodTypeAny, z } from '../../z/index'
 import { zuiKey } from '../../ui/constants'
-import { jsonSchemaToZodStr, jsonSchemaToZui, traverseZodDefinitions } from '.'
-import { zuiToJsonSchema } from '../zui-to-json-schema/zui-extension'
+import { jsonSchemaToZodStr, fromJsonSchemaLegacy, traverseZodDefinitions } from '.'
+import { toJsonSchemaLegacy } from '../zui-to-json-schema/zui-extension'
 import { JSONSchema7 } from 'json-schema'
 
 const testZuiConversion = (zuiObject: ZodTypeAny) => {
-  const jsonSchema = zuiToJsonSchema(zuiObject)
-  const asZui = jsonSchemaToZui(jsonSchema)
-  const convertedJsonSchema = zuiToJsonSchema(asZui)
+  const jsonSchema = toJsonSchemaLegacy(zuiObject)
+  const asZui = fromJsonSchemaLegacy(jsonSchema)
+  const convertedJsonSchema = toJsonSchemaLegacy(asZui)
 
   expect(jsonSchema).toEqual(convertedJsonSchema)
 
@@ -30,7 +30,7 @@ describe('jsonSchemaToZui', () => {
   test('convert record', () => {
     const inner = [z.string().title('Name'), z.number().title('Age')] as const
 
-    expect(zuiToJsonSchema(z.record(inner[0], inner[1]))).toMatchObject({
+    expect(toJsonSchemaLegacy(z.record(inner[0], inner[1]))).toMatchObject({
       type: 'object',
       additionalProperties: {
         type: 'number',
@@ -91,14 +91,14 @@ describe('jsonSchemaToZui', () => {
     ])
     const strategy = { discriminator: true, unionStrategy: 'oneOf' } as const
 
-    const jsonSchema = zuiToJsonSchema(zuiSchema, strategy)
-    const converted = zuiToJsonSchema(jsonSchemaToZui(jsonSchema), strategy)
+    const jsonSchema = toJsonSchemaLegacy(zuiSchema, strategy)
+    const converted = toJsonSchemaLegacy(fromJsonSchemaLegacy(jsonSchema), strategy)
 
     expect(jsonSchema).toEqual(converted)
   })
 
   test('convert object with nested', () => {
-    const zuiSchema = jsonSchemaToZui({
+    const zuiSchema = fromJsonSchemaLegacy({
       type: 'object',
       properties: {
         name: { type: 'string', description: 'Name of person', [zuiKey]: { title: 'title' } },
@@ -150,32 +150,32 @@ describe('jsonSchemaToZui', () => {
 
 describe('Coercion deserialization', () => {
   it('should deserialize coerced strings correctly', () => {
-    const schema = zuiToJsonSchema(z.coerce.string())
-    const asZui = jsonSchemaToZui(schema)
+    const schema = toJsonSchemaLegacy(z.coerce.string())
+    const asZui = fromJsonSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced numbers correctly', () => {
-    const schema = zuiToJsonSchema(z.coerce.number())
-    const asZui = jsonSchemaToZui(schema)
+    const schema = toJsonSchemaLegacy(z.coerce.number())
+    const asZui = fromJsonSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced booleans correctly', () => {
-    const schema = zuiToJsonSchema(z.coerce.boolean())
-    const asZui = jsonSchemaToZui(schema)
+    const schema = toJsonSchemaLegacy(z.coerce.boolean())
+    const asZui = fromJsonSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced dates correctly', () => {
-    const schema = zuiToJsonSchema(z.coerce.date())
-    const asZui = jsonSchemaToZui(schema)
+    const schema = toJsonSchemaLegacy(z.coerce.date())
+    const asZui = fromJsonSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 
   it('should deserialize coerced bigints correctly', () => {
-    const schema = zuiToJsonSchema(z.coerce.bigint())
-    const asZui = jsonSchemaToZui(schema)
+    const schema = toJsonSchemaLegacy(z.coerce.bigint())
+    const asZui = fromJsonSchemaLegacy(schema)
     expect(asZui._def[zuiKey]?.coerce).toStrictEqual(true)
   })
 

--- a/zui/src/transforms/object-to-zui/object-to-zui.test.ts
+++ b/zui/src/transforms/object-to-zui/object-to-zui.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import { fromObject } from '.'
-import { toJsonSchemaLegacy } from '../zui-to-json-schema'
+import { toJSONSchemaLegacy } from '../zui-to-json-schema'
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema'
-import { fromJsonSchemaLegacy } from '../json-schema-to-zui'
+import { fromJSONSchemaLegacy } from '../json-schema-to-zui'
 
 function asSchema(s: JSONSchema7Definition | undefined): JSONSchema7 | undefined {
   if (s === undefined) {
@@ -13,7 +13,7 @@ function asSchema(s: JSONSchema7Definition | undefined): JSONSchema7 | undefined
 
 describe('object-to-zui', () => {
   test('validate object to json', async () => {
-    const schema: JSONSchema7 = toJsonSchemaLegacy(
+    const schema: JSONSchema7 = toJSONSchemaLegacy(
       fromObject({ name: 'Bob', age: 20, birthDate: '1988-11-29', isAdmin: true }, { optional: true }),
     )
 
@@ -39,8 +39,8 @@ describe('object-to-zui', () => {
       address: { street: '123 Main St', city: 'New York', state: 'NY' },
     }
 
-    const schema = toJsonSchemaLegacy(fromObject(obj, { optional: true }))
-    fromJsonSchemaLegacy(schema).parse(obj)
+    const schema = toJSONSchemaLegacy(fromObject(obj, { optional: true }))
+    fromJSONSchemaLegacy(schema).parse(obj)
 
     expect(schema).toEqual({
       additionalProperties: false,
@@ -88,7 +88,7 @@ describe('object-to-zui', () => {
   })
 
   test('should handle null values correctly', () => {
-    const schema: JSONSchema7 = toJsonSchemaLegacy(
+    const schema: JSONSchema7 = toJSONSchemaLegacy(
       fromObject(
         {
           test: null,
@@ -107,7 +107,7 @@ describe('object-to-zui', () => {
   })
 
   test('should handle nested objects correctly', () => {
-    const schema: JSONSchema7 = toJsonSchemaLegacy(
+    const schema: JSONSchema7 = toJSONSchemaLegacy(
       fromObject(
         {
           user: {
@@ -134,7 +134,7 @@ describe('object-to-zui', () => {
   })
 
   test('should handle arrays correctly', () => {
-    const schema: JSONSchema7 = toJsonSchemaLegacy(
+    const schema: JSONSchema7 = toJSONSchemaLegacy(
       fromObject(
         {
           tags: ['tag1', 'tag2'],
@@ -158,14 +158,14 @@ describe('object-to-zui', () => {
   })
 
   test('should handle empty objects correctly', () => {
-    const schema: JSONSchema7 = toJsonSchemaLegacy(fromObject({}))
+    const schema: JSONSchema7 = toJSONSchemaLegacy(fromObject({}))
     expect(schema).toHaveProperty('type', 'object')
     expect(schema).toHaveProperty('properties')
     expect(Object.keys(schema.properties || {})).toHaveLength(0)
   })
 
   test('should handle datetime with timezone correctly', () => {
-    const schema: JSONSchema7 = toJsonSchemaLegacy(
+    const schema: JSONSchema7 = toJSONSchemaLegacy(
       fromObject({
         eventTime: '2023-03-15T14:00:00+01:00',
       }),
@@ -180,7 +180,7 @@ describe('object-to-zui', () => {
   })
 
   test('empty objects are considered passtrough, other are strict', () => {
-    const schema: JSONSchema7 = toJsonSchemaLegacy(
+    const schema: JSONSchema7 = toJSONSchemaLegacy(
       fromObject({ input: {}, test: { output: {} }, fixed: { value: true } }),
     )
 
@@ -199,7 +199,7 @@ describe('object-to-zui', () => {
   })
 
   test('when passtrough is set to true, they are all passtrough', () => {
-    const schema: JSONSchema7 = toJsonSchemaLegacy(
+    const schema: JSONSchema7 = toJSONSchemaLegacy(
       fromObject({ input: {}, test: { output: {} }, fixed: { value: true } }, { passtrough: true }),
     )
 

--- a/zui/src/transforms/object-to-zui/object-to-zui.test.ts
+++ b/zui/src/transforms/object-to-zui/object-to-zui.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import { fromObject } from '.'
-import { zuiToJsonSchema } from '../zui-to-json-schema'
+import { toJsonSchemaLegacy } from '../zui-to-json-schema'
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema'
-import { fromJsonSchema } from '../json-schema-to-zui-next'
+import { fromJsonSchemaLegacy } from '../json-schema-to-zui'
 
 function asSchema(s: JSONSchema7Definition | undefined): JSONSchema7 | undefined {
   if (s === undefined) {
@@ -13,7 +13,7 @@ function asSchema(s: JSONSchema7Definition | undefined): JSONSchema7 | undefined
 
 describe('object-to-zui', () => {
   test('validate object to json', async () => {
-    const schema: JSONSchema7 = zuiToJsonSchema(
+    const schema: JSONSchema7 = toJsonSchemaLegacy(
       fromObject({ name: 'Bob', age: 20, birthDate: '1988-11-29', isAdmin: true }, { optional: true }),
     )
 
@@ -39,8 +39,8 @@ describe('object-to-zui', () => {
       address: { street: '123 Main St', city: 'New York', state: 'NY' },
     }
 
-    const schema = zuiToJsonSchema(fromObject(obj, { optional: true }))
-    fromJsonSchema(schema).parse(obj)
+    const schema = toJsonSchemaLegacy(fromObject(obj, { optional: true }))
+    fromJsonSchemaLegacy(schema).parse(obj)
 
     expect(schema).toEqual({
       additionalProperties: false,
@@ -88,7 +88,7 @@ describe('object-to-zui', () => {
   })
 
   test('should handle null values correctly', () => {
-    const schema: JSONSchema7 = zuiToJsonSchema(
+    const schema: JSONSchema7 = toJsonSchemaLegacy(
       fromObject(
         {
           test: null,
@@ -107,7 +107,7 @@ describe('object-to-zui', () => {
   })
 
   test('should handle nested objects correctly', () => {
-    const schema: JSONSchema7 = zuiToJsonSchema(
+    const schema: JSONSchema7 = toJsonSchemaLegacy(
       fromObject(
         {
           user: {
@@ -134,7 +134,7 @@ describe('object-to-zui', () => {
   })
 
   test('should handle arrays correctly', () => {
-    const schema: JSONSchema7 = zuiToJsonSchema(
+    const schema: JSONSchema7 = toJsonSchemaLegacy(
       fromObject(
         {
           tags: ['tag1', 'tag2'],
@@ -158,14 +158,14 @@ describe('object-to-zui', () => {
   })
 
   test('should handle empty objects correctly', () => {
-    const schema: JSONSchema7 = zuiToJsonSchema(fromObject({}))
+    const schema: JSONSchema7 = toJsonSchemaLegacy(fromObject({}))
     expect(schema).toHaveProperty('type', 'object')
     expect(schema).toHaveProperty('properties')
     expect(Object.keys(schema.properties || {})).toHaveLength(0)
   })
 
   test('should handle datetime with timezone correctly', () => {
-    const schema: JSONSchema7 = zuiToJsonSchema(
+    const schema: JSONSchema7 = toJsonSchemaLegacy(
       fromObject({
         eventTime: '2023-03-15T14:00:00+01:00',
       }),
@@ -180,7 +180,9 @@ describe('object-to-zui', () => {
   })
 
   test('empty objects are considered passtrough, other are strict', () => {
-    const schema: JSONSchema7 = zuiToJsonSchema(fromObject({ input: {}, test: { output: {} }, fixed: { value: true } }))
+    const schema: JSONSchema7 = toJsonSchemaLegacy(
+      fromObject({ input: {}, test: { output: {} }, fixed: { value: true } }),
+    )
 
     const testSchema = asSchema(schema.properties?.test)
     const fixedSchema = asSchema(schema.properties?.fixed)
@@ -197,7 +199,7 @@ describe('object-to-zui', () => {
   })
 
   test('when passtrough is set to true, they are all passtrough', () => {
-    const schema: JSONSchema7 = zuiToJsonSchema(
+    const schema: JSONSchema7 = toJsonSchemaLegacy(
       fromObject({ input: {}, test: { output: {} }, fixed: { value: true } }, { passtrough: true }),
     )
 

--- a/zui/src/transforms/transform-pipeline.test.ts
+++ b/zui/src/transforms/transform-pipeline.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import z from '../z'
-import { toJsonSchema } from './zui-to-json-schema-next'
-import { fromJsonSchema } from './json-schema-to-zui-next'
+import { toJSONSchema } from './zui-to-json-schema-next'
+import { fromJSONSchema } from './json-schema-to-zui-next'
 import * as errors from './common/errors'
 
 const assert = (src: z.Schema) => ({
   toTransformBackToItself: () => {
-    const jsonSchema = toJsonSchema(src)
-    const actual = fromJsonSchema(jsonSchema)
+    const jsonSchema = toJSONSchema(src)
+    const actual = fromJSONSchema(jsonSchema)
     const expected = src
     let msg: string | undefined = undefined
     try {
@@ -131,7 +131,7 @@ describe.concurrent('transformPipeline', () => {
       const srcSchema = z.string().includes('foo')
 
       // Act
-      const dstSchema = fromJsonSchema(toJsonSchema(srcSchema)) as z.ZodString
+      const dstSchema = fromJSONSchema(toJSONSchema(srcSchema)) as z.ZodString
 
       // Assert
       const check = dstSchema._def.checks[0]
@@ -143,7 +143,7 @@ describe.concurrent('transformPipeline', () => {
       const srcSchema = z.string().startsWith('foo')
 
       // Act
-      const dstSchema = fromJsonSchema(toJsonSchema(srcSchema)) as z.ZodString
+      const dstSchema = fromJSONSchema(toJSONSchema(srcSchema)) as z.ZodString
 
       // Assert
       const check = dstSchema._def.checks[0]
@@ -155,42 +155,42 @@ describe.concurrent('transformPipeline', () => {
       const srcSchema = z.string().endsWith('foo')
 
       // Act
-      const dstSchema = fromJsonSchema(toJsonSchema(srcSchema)) as z.ZodString
+      const dstSchema = fromJSONSchema(toJSONSchema(srcSchema)) as z.ZodString
 
       // Assert
       const check = dstSchema._def.checks[0]
       expect(check?.kind).toBe('regex')
       expect(check?.kind === 'regex' && check.regex.source).toBe('foo$')
     })
-    it('throws UnsupportedZuiCheckToJsonSchemaError when using .trim', async () => {
+    it('throws UnsupportedZuiCheckToJSONSchemaError when using .trim', async () => {
       // Arrange
       const srcSchema = z.string().trim()
 
       // Act
-      const act = () => toJsonSchema(srcSchema)
+      const act = () => toJSONSchema(srcSchema)
 
       // Assert
-      expect(act).toThrowError(errors.UnsupportedZuiCheckToJsonSchemaError)
+      expect(act).toThrowError(errors.UnsupportedZuiCheckToJSONSchemaError)
     })
-    it('throws UnsupportedZuiCheckToJsonSchemaError when using .toLowerCase', async () => {
+    it('throws UnsupportedZuiCheckToJSONSchemaError when using .toLowerCase', async () => {
       // Arrange
       const srcSchema = z.string().toLowerCase()
 
       // Act
-      const act = () => toJsonSchema(srcSchema)
+      const act = () => toJSONSchema(srcSchema)
 
       // Assert
-      expect(act).toThrowError(errors.UnsupportedZuiCheckToJsonSchemaError)
+      expect(act).toThrowError(errors.UnsupportedZuiCheckToJSONSchemaError)
     })
-    it('throws UnsupportedZuiCheckToJsonSchemaError when using .toUpperCase', async () => {
+    it('throws UnsupportedZuiCheckToJSONSchemaError when using .toUpperCase', async () => {
       // Arrange
       const srcSchema = z.string().toUpperCase()
 
       // Act
-      const act = () => toJsonSchema(srcSchema)
+      const act = () => toJSONSchema(srcSchema)
 
       // Assert
-      expect(act).toThrowError(errors.UnsupportedZuiCheckToJsonSchemaError)
+      expect(act).toThrowError(errors.UnsupportedZuiCheckToJSONSchemaError)
     })
   })
 
@@ -316,15 +316,15 @@ describe.concurrent('transformPipeline', () => {
     })
   })
 
-  it('should throw UnsupportedZuiToJsonSchemaError for ZodBigInt', async () => {
+  it('should throw UnsupportedZuiToJSONSchemaError for ZodBigInt', async () => {
     // Arrange
     const srcSchema = z.bigint()
 
     // Act
-    const act = () => toJsonSchema(srcSchema)
+    const act = () => toJSONSchema(srcSchema)
 
     // Assert
-    expect(act).toThrowError(errors.UnsupportedZuiToJsonSchemaError)
+    expect(act).toThrowError(errors.UnsupportedZuiToJSONSchemaError)
   })
 
   it('should map ZodBoolean to itself', async () => {
@@ -332,15 +332,15 @@ describe.concurrent('transformPipeline', () => {
     assert(srcSchema).toTransformBackToItself()
   })
 
-  it('should throw UnsupportedZuiToJsonSchemaError for ZodDate', async () => {
+  it('should throw UnsupportedZuiToJSONSchemaError for ZodDate', async () => {
     // Arrange
     const srcSchema = z.date()
 
     // Act
-    const act = () => toJsonSchema(srcSchema)
+    const act = () => toJSONSchema(srcSchema)
 
     // Assert
-    expect(act).toThrowError(errors.UnsupportedZuiToJsonSchemaError)
+    expect(act).toThrowError(errors.UnsupportedZuiToJSONSchemaError)
   })
 
   it('should map ZodUndefined to itself', async () => {

--- a/zui/src/transforms/zui-to-json-schema-next/index.test.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/index.test.ts
@@ -1,72 +1,72 @@
 import * as errs from '../common/errors'
 import z from '../../z'
 import { describe, test, expect } from 'vitest'
-import { toJsonSchema } from './index'
+import { toJSONSchema } from './index'
 
-describe('zuiToJsonSchemaNext', () => {
+describe('zuiToJSONSchemaNext', () => {
   test('should map ZodString to StringSchema', () => {
-    const schema = toJsonSchema(z.string())
+    const schema = toJSONSchema(z.string())
     expect(schema).toEqual({ type: 'string' })
   })
 
   test('should map ZodNumber to NumberSchema', () => {
-    const schema = toJsonSchema(z.number())
+    const schema = toJSONSchema(z.number())
     expect(schema).toEqual({ type: 'number' })
   })
 
   test('should not support ZodNaN', () => {
-    expect(() => toJsonSchema(z.nan())).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.nan())).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should not support ZodBigInt', () => {
-    expect(() => toJsonSchema(z.bigint())).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.bigint())).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should map ZodBoolean to BooleanSchema', () => {
-    const schema = toJsonSchema(z.boolean())
+    const schema = toJSONSchema(z.boolean())
     expect(schema).toEqual({ type: 'boolean' })
   })
 
   test('should not support ZodDate', () => {
-    expect(() => toJsonSchema(z.date())).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.date())).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should map ZodUndefined to UndefinedSchema', () => {
-    const schema = toJsonSchema(z.undefined())
+    const schema = toJSONSchema(z.undefined())
     expect(schema).toEqual({ not: true, 'x-zui': { def: { typeName: 'ZodUndefined' } } })
   })
 
   test('should map ZodNull to NullSchema', () => {
-    const schema = toJsonSchema(z.null())
+    const schema = toJSONSchema(z.null())
     expect(schema).toEqual({ type: 'null' })
   })
 
   test('should map ZodAny to AnySchema', () => {
-    const schema = toJsonSchema(z.any())
+    const schema = toJSONSchema(z.any())
     expect(schema).toEqual({})
   })
 
   test('should map ZodUnknown to UnknownSchema', () => {
-    const schema = toJsonSchema(z.unknown())
+    const schema = toJSONSchema(z.unknown())
     expect(schema).toEqual({ 'x-zui': { def: { typeName: 'ZodUnknown' } } })
   })
 
   test('should map ZodNever to NeverSchema', () => {
-    const schema = toJsonSchema(z.never())
+    const schema = toJSONSchema(z.never())
     expect(schema).toEqual({ not: true })
   })
 
   test('should not support ZodVoid', () => {
-    expect(() => toJsonSchema(z.void())).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.void())).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should map ZodArray to ArraySchema', () => {
-    const schema = toJsonSchema(z.array(z.string()))
+    const schema = toJSONSchema(z.array(z.string()))
     expect(schema).toEqual({ type: 'array', items: { type: 'string' } })
   })
 
   test('should map ZodObject to ObjectSchema', () => {
-    const schema = toJsonSchema(z.object({ name: z.string() }))
+    const schema = toJSONSchema(z.object({ name: z.string() }))
     expect(schema).toEqual({
       type: 'object',
       properties: { name: { type: 'string' } },
@@ -76,7 +76,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodObject with optional fields to ObjectSchema', () => {
-    const schema = toJsonSchema(
+    const schema = toJSONSchema(
       z.object({
         name: z.string(),
         age: z.number().optional(),
@@ -100,7 +100,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map strict ZodObject to ObjectSchema with addtionalProperties never', () => {
-    const schema = toJsonSchema(z.object({ name: z.string() }).strict())
+    const schema = toJSONSchema(z.object({ name: z.string() }).strict())
     expect(schema).toEqual({
       type: 'object',
       properties: { name: { type: 'string' } },
@@ -110,7 +110,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map passthrough ZodObject to ObjectSchema with addtionalProperties any', () => {
-    const schema = toJsonSchema(z.object({ name: z.string() }).passthrough())
+    const schema = toJSONSchema(z.object({ name: z.string() }).passthrough())
     expect(schema).toEqual({
       type: 'object',
       properties: { name: { type: 'string' } },
@@ -120,7 +120,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodObject with catchall ZodNumber to ObjectSchema with addtionalProperties number', () => {
-    const schema = toJsonSchema(z.object({ name: z.string() }).catchall(z.number()))
+    const schema = toJSONSchema(z.object({ name: z.string() }).catchall(z.number()))
     expect(schema).toEqual({
       type: 'object',
       properties: { name: { type: 'string' } },
@@ -133,7 +133,7 @@ describe('zuiToJsonSchemaNext', () => {
     const description1 = 'The ID or Name of the table'
     const description2 = 'Notes about the task'
     const description3 = 'The ID of the user who will be assigned to the task'
-    const schema = toJsonSchema(
+    const schema = toJSONSchema(
       z.object({
         tableIdOrName: z.string().describe(description1),
         notes: z.string().optional().describe(description2),
@@ -163,14 +163,14 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodUnion to UnionSchema', () => {
-    const schema = toJsonSchema(z.union([z.string(), z.number()]))
+    const schema = toJSONSchema(z.union([z.string(), z.number()]))
     expect(schema).toEqual({
       anyOf: [{ type: 'string' }, { type: 'number' }],
     })
   })
 
   test('should map ZodDiscriminatedUnion to UnionSchema', () => {
-    const schema = toJsonSchema(
+    const schema = toJSONSchema(
       z.discriminatedUnion('type', [
         z.object({ type: z.literal('A'), a: z.string() }),
         z.object({ type: z.literal('B'), b: z.number() }),
@@ -195,7 +195,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodIntersection to IntersectionSchema', () => {
-    const schema = toJsonSchema(z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() })))
+    const schema = toJSONSchema(z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() })))
     expect(schema).toEqual({
       allOf: [
         {
@@ -213,7 +213,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodIntersection of strict schemas to IntersectionSchema removing additional properties', () => {
-    const schema = toJsonSchema(
+    const schema = toJSONSchema(
       z.intersection(
         z.object({ a: z.string() }).strict(), //
         z.object({ b: z.number() }).strict(),
@@ -237,7 +237,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodTuple to TupleSchema', () => {
-    const schema = toJsonSchema(z.tuple([z.string(), z.number()]))
+    const schema = toJSONSchema(z.tuple([z.string(), z.number()]))
     expect(schema).toEqual({
       type: 'array',
       items: [{ type: 'string' }, { type: 'number' }],
@@ -245,7 +245,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodRecord to RecordSchema', () => {
-    const schema = toJsonSchema(z.record(z.number()))
+    const schema = toJSONSchema(z.record(z.number()))
     expect(schema).toEqual({
       type: 'object',
       additionalProperties: { type: 'number' },
@@ -253,11 +253,11 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should not support ZodMap', () => {
-    expect(() => toJsonSchema(z.map(z.string(), z.number()))).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.map(z.string(), z.number()))).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should map ZodSet to SetSchema', () => {
-    const schema = toJsonSchema(z.set(z.string()))
+    const schema = toJSONSchema(z.set(z.string()))
     expect(schema).toEqual({
       type: 'array',
       items: { type: 'string' },
@@ -266,35 +266,35 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should not support ZodFunction', () => {
-    expect(() => toJsonSchema(z.function())).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.function())).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should not support ZodLazy', () => {
-    expect(() => toJsonSchema(z.lazy(() => z.string()))).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.lazy(() => z.string()))).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should map ZodLiteral to LiteralSchema', () => {
-    const stringSchema = toJsonSchema(z.literal('a'))
+    const stringSchema = toJSONSchema(z.literal('a'))
     expect(stringSchema).toEqual({ type: 'string', const: 'a' })
 
-    const numberSchema = toJsonSchema(z.literal(1))
+    const numberSchema = toJSONSchema(z.literal(1))
     expect(numberSchema).toEqual({ type: 'number', const: 1 })
 
-    const booleanSchema = toJsonSchema(z.literal(true))
+    const booleanSchema = toJSONSchema(z.literal(true))
     expect(booleanSchema).toEqual({ type: 'boolean', const: true })
 
-    const nullSchema = toJsonSchema(z.literal(null))
+    const nullSchema = toJSONSchema(z.literal(null))
     expect(nullSchema).toEqual({ type: 'null' })
 
-    const undefinedSchema = toJsonSchema(z.literal(undefined))
+    const undefinedSchema = toJSONSchema(z.literal(undefined))
     expect(undefinedSchema).toEqual({ not: true, 'x-zui': { def: { typeName: 'ZodUndefined' } } })
 
-    expect(() => toJsonSchema(z.literal(BigInt(1)))).toThrowError(errs.ZuiToJsonSchemaError)
-    expect(() => toJsonSchema(z.literal(Symbol('a')))).toThrowError(errs.ZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.literal(BigInt(1)))).toThrowError(errs.ZuiToJSONSchemaError)
+    expect(() => toJSONSchema(z.literal(Symbol('a')))).toThrowError(errs.ZuiToJSONSchemaError)
   })
 
   test('should map ZodEnum to EnumSchema', () => {
-    const schema = toJsonSchema(z.enum(['a', 'b']))
+    const schema = toJSONSchema(z.enum(['a', 'b']))
     expect(schema).toEqual({
       type: 'string',
       enum: ['a', 'b'],
@@ -302,11 +302,11 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should not support ZodEffects', () => {
-    expect(() => toJsonSchema(z.string().refine((s) => s === s.toUpperCase()))).toThrowError(
-      errs.UnsupportedZuiToJsonSchemaError,
+    expect(() => toJSONSchema(z.string().refine((s) => s === s.toUpperCase()))).toThrowError(
+      errs.UnsupportedZuiToJSONSchemaError,
     )
-    expect(() => toJsonSchema(z.string().transform((s) => s.toUpperCase()))).toThrowError(
-      errs.UnsupportedZuiToJsonSchemaError,
+    expect(() => toJSONSchema(z.string().transform((s) => s.toUpperCase()))).toThrowError(
+      errs.UnsupportedZuiToJSONSchemaError,
     )
   })
 
@@ -315,11 +315,11 @@ describe('zuiToJsonSchemaNext', () => {
       Apple = 'apple',
       Banana = 'banana',
     }
-    expect(() => toJsonSchema(z.nativeEnum(Fruit))).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.nativeEnum(Fruit))).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should map ZodOptional to OptionalSchema', () => {
-    const schema = toJsonSchema(z.string().optional())
+    const schema = toJSONSchema(z.string().optional())
     expect(schema).toEqual({
       anyOf: [{ type: 'string' }, { not: true, 'x-zui': { def: { typeName: 'ZodUndefined' } } }],
       'x-zui': { def: { typeName: 'ZodOptional' } },
@@ -327,15 +327,15 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodNullable to NullableSchema', () => {
-    const schema = toJsonSchema(z.string().nullable())
+    const schema = toJSONSchema(z.string().nullable())
     expect(schema).toEqual({
       anyOf: [{ type: 'string' }, { type: 'null' }],
       'x-zui': { def: { typeName: 'ZodNullable' } },
     })
   })
 
-  test('should map ZodDefault to ZuiJsonSchema with default anotation', () => {
-    const schema = toJsonSchema(z.string().default('hello'))
+  test('should map ZodDefault to ZuiJSONSchema with default anotation', () => {
+    const schema = toJSONSchema(z.string().default('hello'))
     expect(schema).toEqual({
       type: 'string',
       default: 'hello',
@@ -343,27 +343,27 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should not support ZodCatch', () => {
-    expect(() => toJsonSchema(z.string().catch('apple'))).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.string().catch('apple'))).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should not support ZodPromise', () => {
-    expect(() => toJsonSchema(z.string().promise())).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.string().promise())).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should not support ZodBranded', () => {
-    expect(() => toJsonSchema(z.string().brand('apple'))).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.string().brand('apple'))).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should not support ZodPipeline', () => {
-    expect(() => toJsonSchema(z.string().pipe(z.string()))).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.string().pipe(z.string()))).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
   test('should not support ZodSymbol', () => {
-    expect(() => toJsonSchema(z.symbol())).toThrowError(errs.UnsupportedZuiToJsonSchemaError)
+    expect(() => toJSONSchema(z.symbol())).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
-  test('should map ZodReadonly to ZuiJsonSchema with readOnly anotation', () => {
-    const schema = toJsonSchema(z.string().readonly())
+  test('should map ZodReadonly to ZuiJSONSchema with readOnly anotation', () => {
+    const schema = toJSONSchema(z.string().readonly())
     expect(schema).toEqual({
       type: 'string',
       readOnly: true,
@@ -371,7 +371,7 @@ describe('zuiToJsonSchemaNext', () => {
   })
 
   test('should map ZodRef to RefSchema', () => {
-    const schema = toJsonSchema(z.ref('foo'))
+    const schema = toJSONSchema(z.ref('foo'))
     expect(schema).toEqual({ $ref: 'foo' })
   })
 })

--- a/zui/src/transforms/zui-to-json-schema-next/index.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/index.ts
@@ -12,7 +12,7 @@ import { zodTupleToJsonTuple } from './type-processors/tuple'
  * @param schema zui schema
  * @returns ZUI flavored JSON schema
  */
-export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
+export function toJSONSchema(schema: z.Schema): json.ZuiJSONSchema {
   const schemaTyped = schema as z.ZodFirstPartySchemaTypes
   const def = schemaTyped._def
 
@@ -24,10 +24,10 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
       return zodNumberToJsonNumber(schemaTyped as z.ZodNumber) satisfies json.NumberSchema
 
     case z.ZodFirstPartyTypeKind.ZodNaN:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodNaN)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodNaN)
 
     case z.ZodFirstPartyTypeKind.ZodBigInt:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodBigInt, {
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodBigInt, {
         suggestedAlternative: 'serialize bigint to string',
       })
 
@@ -39,7 +39,7 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
       } satisfies json.BooleanSchema
 
     case z.ZodFirstPartyTypeKind.ZodDate:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodDate, {
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodDate, {
         suggestedAlternative: 'use z.string().datetime() instead',
       })
 
@@ -69,10 +69,10 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
       } satisfies json.NeverSchema
 
     case z.ZodFirstPartyTypeKind.ZodVoid:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodVoid)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodVoid)
 
     case z.ZodFirstPartyTypeKind.ZodArray:
-      return zodArrayToJsonArray(schemaTyped as z.ZodArray, toJsonSchema) satisfies json.ArraySchema
+      return zodArrayToJsonArray(schemaTyped as z.ZodArray, toJSONSchema) satisfies json.ArraySchema
 
     case z.ZodFirstPartyTypeKind.ZodObject:
       const shape = Object.entries(def.shape())
@@ -80,11 +80,11 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
       const required = requiredProperties.length ? requiredProperties.map(([key]) => key) : undefined
       const properties = shape
         .map(([key, value]) => [key, value.mandatory()] satisfies [string, z.ZodType])
-        .map(([key, value]) => [key, toJsonSchema(value)] satisfies [string, json.ZuiJsonSchema])
+        .map(([key, value]) => [key, toJSONSchema(value)] satisfies [string, json.ZuiJSONSchema])
 
       let additionalProperties: json.ObjectSchema['additionalProperties'] = false
       if (def.unknownKeys instanceof z.ZodType) {
-        additionalProperties = toJsonSchema(def.unknownKeys)
+        additionalProperties = toJSONSchema(def.unknownKeys)
       } else if (def.unknownKeys === 'passthrough') {
         additionalProperties = true
       }
@@ -101,20 +101,20 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
     case z.ZodFirstPartyTypeKind.ZodUnion:
       return {
         description: def.description,
-        anyOf: def.options.map((option) => toJsonSchema(option)),
+        anyOf: def.options.map((option) => toJSONSchema(option)),
         'x-zui': def['x-zui'],
       } satisfies json.UnionSchema
 
     case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
       return {
         description: def.description,
-        anyOf: def.options.map((option) => toJsonSchema(option)),
+        anyOf: def.options.map((option) => toJSONSchema(option)),
         'x-zui': def['x-zui'],
       } satisfies json.UnionSchema
 
     case z.ZodFirstPartyTypeKind.ZodIntersection:
-      const left = toJsonSchema(def.left)
-      const right = toJsonSchema(def.right)
+      const left = toJSONSchema(def.left)
+      const right = toJSONSchema(def.right)
 
       /**
        * TODO: Potential conflict between `additionalProperties` in the left and right schemas.
@@ -139,27 +139,27 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
       } satisfies json.IntersectionSchema
 
     case z.ZodFirstPartyTypeKind.ZodTuple:
-      return zodTupleToJsonTuple(schemaTyped as z.ZodTuple, toJsonSchema) satisfies json.TupleSchema
+      return zodTupleToJsonTuple(schemaTyped as z.ZodTuple, toJSONSchema) satisfies json.TupleSchema
 
     case z.ZodFirstPartyTypeKind.ZodRecord:
       return {
         type: 'object',
         description: def.description,
-        additionalProperties: toJsonSchema(def.valueType),
+        additionalProperties: toJSONSchema(def.valueType),
         'x-zui': def['x-zui'],
       } satisfies json.RecordSchema
 
     case z.ZodFirstPartyTypeKind.ZodMap:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodMap)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodMap)
 
     case z.ZodFirstPartyTypeKind.ZodSet:
-      return zodSetToJsonSet(schemaTyped as z.ZodSet, toJsonSchema) satisfies json.SetSchema
+      return zodSetToJsonSet(schemaTyped as z.ZodSet, toJSONSchema) satisfies json.SetSchema
 
     case z.ZodFirstPartyTypeKind.ZodFunction:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodFunction)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodFunction)
 
     case z.ZodFirstPartyTypeKind.ZodLazy:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodLazy)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodLazy)
 
     case z.ZodFirstPartyTypeKind.ZodLiteral:
       if (typeof def.value === 'string') {
@@ -190,7 +190,7 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
       } else {
         z.util.assertEqual<bigint | symbol, typeof def.value>(true)
         const unsupportedLiteral = typeof def.value
-        throw new err.ZuiToJsonSchemaError(`Unsupported literal type: "${unsupportedLiteral}"`)
+        throw new err.ZuiToJSONSchemaError(`Unsupported literal type: "${unsupportedLiteral}"`)
       }
 
     case z.ZodFirstPartyTypeKind.ZodEnum:
@@ -202,15 +202,15 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
       } satisfies json.EnumSchema
 
     case z.ZodFirstPartyTypeKind.ZodEffects:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodEffects)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodEffects)
 
     case z.ZodFirstPartyTypeKind.ZodNativeEnum:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodNativeEnum)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodNativeEnum)
 
     case z.ZodFirstPartyTypeKind.ZodOptional:
       return {
         description: def.description,
-        anyOf: [toJsonSchema(def.innerType), undefinedSchema()],
+        anyOf: [toJSONSchema(def.innerType), undefinedSchema()],
         'x-zui': {
           ...def['x-zui'],
           def: { typeName: z.ZodFirstPartyTypeKind.ZodOptional },
@@ -219,7 +219,7 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
 
     case z.ZodFirstPartyTypeKind.ZodNullable:
       return {
-        anyOf: [toJsonSchema(def.innerType), nullSchema()],
+        anyOf: [toJSONSchema(def.innerType), nullSchema()],
         'x-zui': {
           ...def['x-zui'],
           def: { typeName: z.ZodFirstPartyTypeKind.ZodNullable },
@@ -229,30 +229,30 @@ export function toJsonSchema(schema: z.Schema): json.ZuiJsonSchema {
     case z.ZodFirstPartyTypeKind.ZodDefault:
       // ZodDefault is not treated as a metadata root so we don't need to preserve x-zui
       return {
-        ...toJsonSchema(def.innerType),
+        ...toJSONSchema(def.innerType),
         default: def.defaultValue(),
       }
 
     case z.ZodFirstPartyTypeKind.ZodCatch:
       // TODO: could be supported using if-else json schema
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodCatch)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodCatch)
 
     case z.ZodFirstPartyTypeKind.ZodPromise:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodPromise)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodPromise)
 
     case z.ZodFirstPartyTypeKind.ZodBranded:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodBranded)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodBranded)
 
     case z.ZodFirstPartyTypeKind.ZodPipeline:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodPipeline)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodPipeline)
 
     case z.ZodFirstPartyTypeKind.ZodSymbol:
-      throw new err.UnsupportedZuiToJsonSchemaError(z.ZodFirstPartyTypeKind.ZodPipeline)
+      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodPipeline)
 
     case z.ZodFirstPartyTypeKind.ZodReadonly:
       // ZodReadonly is not treated as a metadata root so we don't need to preserve x-zui
       return {
-        ...toJsonSchema(def.innerType),
+        ...toJSONSchema(def.innerType),
         readOnly: true,
       }
 

--- a/zui/src/transforms/zui-to-json-schema-next/type-processors/array.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/type-processors/array.ts
@@ -4,7 +4,7 @@ import * as json from '../../common/json-schema'
 
 export const zodArrayToJsonArray = (
   zodArray: z.ZodArray,
-  toSchema: (x: z.ZodTypeAny) => json.ZuiJsonSchema,
+  toSchema: (x: z.ZodTypeAny) => json.ZuiJSONSchema,
 ): json.ArraySchema => {
   const schema: json.ArraySchema = {
     type: 'array',

--- a/zui/src/transforms/zui-to-json-schema-next/type-processors/set.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/type-processors/set.ts
@@ -4,7 +4,7 @@ import * as json from '../../common/json-schema'
 
 export const zodSetToJsonSet = (
   zodSet: z.ZodSet,
-  toSchema: (x: z.ZodTypeAny) => json.ZuiJsonSchema,
+  toSchema: (x: z.ZodTypeAny) => json.ZuiJSONSchema,
 ): json.SetSchema => {
   const schema: json.SetSchema = {
     type: 'array',

--- a/zui/src/transforms/zui-to-json-schema-next/type-processors/string.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/type-processors/string.ts
@@ -81,7 +81,7 @@ export const zodStringToJsonString = (zodString: z.ZodString): json.StringSchema
         schema.maxLength = Math.max(0, check.value)
         break
       default:
-        throw new errors.UnsupportedZuiCheckToJsonSchemaError({
+        throw new errors.UnsupportedZuiCheckToJSONSchemaError({
           zodType: z.ZodFirstPartyTypeKind.ZodString,
           checkKind: check.kind,
         })

--- a/zui/src/transforms/zui-to-json-schema-next/type-processors/tuple.ts
+++ b/zui/src/transforms/zui-to-json-schema-next/type-processors/tuple.ts
@@ -4,7 +4,7 @@ import * as json from '../../common/json-schema'
 
 export const zodTupleToJsonTuple = (
   zodTuple: z.ZodTuple,
-  toSchema: (x: z.ZodTypeAny) => json.ZuiJsonSchema,
+  toSchema: (x: z.ZodTypeAny) => json.ZuiJSONSchema,
 ): json.TupleSchema => {
   const schema: json.TupleSchema = {
     type: 'array',

--- a/zui/src/transforms/zui-to-json-schema/index.ts
+++ b/zui/src/transforms/zui-to-json-schema/index.ts
@@ -1,1 +1,1 @@
-export { toJsonSchemaLegacy } from './zui-extension'
+export { toJSONSchemaLegacy } from './zui-extension'

--- a/zui/src/transforms/zui-to-json-schema/index.ts
+++ b/zui/src/transforms/zui-to-json-schema/index.ts
@@ -1,4 +1,1 @@
-import { zodToJsonSchema } from './zodToJsonSchema'
-import { zuiToJsonSchema } from './zui-extension'
-
-export { zodToJsonSchema, zuiToJsonSchema }
+export { toJsonSchemaLegacy } from './zui-extension'

--- a/zui/src/transforms/zui-to-json-schema/zui-extension.test.ts
+++ b/zui/src/transforms/zui-to-json-schema/zui-extension.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, it } from 'vitest'
-import { zuiToJsonSchema } from './zui-extension'
+import { toJsonSchemaLegacy } from './zui-extension'
 import { z } from '../../z/index'
 import { zuiKey } from '../../ui/constants'
 
@@ -10,7 +10,7 @@ describe('zuiToJsonSchema', () => {
       age: z.number().max(100).min(0).title('Age').describe('Age in years').default(20),
     })
 
-    const jsonSchema = zuiToJsonSchema(schema)
+    const jsonSchema = toJsonSchemaLegacy(schema)
 
     expect(jsonSchema).toEqual({
       additionalProperties: false,
@@ -40,7 +40,7 @@ describe('zuiToJsonSchema', () => {
 
   test('enums', () => {
     expect(
-      zuiToJsonSchema(
+      toJsonSchemaLegacy(
         z.object({
           fruit: z.enum(['Apple', 'Banana', 'Orange']),
         }),
@@ -68,7 +68,7 @@ describe('zuiToJsonSchema', () => {
         .displayAs({ id: 'customstringcomponent', params: { multiline: true } }),
     })
 
-    const jsonSchema = zuiToJsonSchema(schema)
+    const jsonSchema = toJsonSchemaLegacy(schema)
     expect(jsonSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -94,7 +94,7 @@ describe('zuiToJsonSchema', () => {
   test('examples are available on json schema', () => {
     const schema = z.string()
 
-    const jsonSchema = zuiToJsonSchema(schema, { $schemaUrl: false })
+    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: false })
     expect(jsonSchema).toEqual({
       type: 'string',
       [zuiKey]: {},
@@ -104,7 +104,7 @@ describe('zuiToJsonSchema', () => {
   test('record with a value works', () => {
     const schema = z.record(z.string().max(30)).describe('hello')
 
-    const jsonSchema = zuiToJsonSchema(schema, { $schemaUrl: false })
+    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: false })
     expect(jsonSchema).toEqual({
       additionalProperties: {
         maxLength: 30,
@@ -120,7 +120,7 @@ describe('zuiToJsonSchema', () => {
   test('record with second parameter', () => {
     const schema = z.record(z.string(), z.number().max(30), {}).describe('hello')
 
-    const jsonSchema = zuiToJsonSchema(schema, { $schemaUrl: false })
+    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: false })
     expect(jsonSchema).toEqual({
       additionalProperties: {
         maximum: 30,
@@ -136,7 +136,7 @@ describe('zuiToJsonSchema', () => {
   test('record with second parameter', () => {
     const schema = z.object({})
 
-    const jsonSchema = zuiToJsonSchema(schema, { $schemaUrl: 'http://schema.com' })
+    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: 'http://schema.com' })
     expect(jsonSchema).toEqual({
       $schema: 'http://schema.com',
       additionalProperties: false,
@@ -149,7 +149,7 @@ describe('zuiToJsonSchema', () => {
   test('record with second parameter', () => {
     const schema = z.object({ multipleTypes: z.union([z.string(), z.number()]) })
 
-    const jsonSchema = zuiToJsonSchema(schema, { $schemaUrl: false })
+    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: false })
     expect(jsonSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -175,7 +175,7 @@ describe('zuiToJsonSchema', () => {
       .min(1)
       .describe('Array of objects with validation')
 
-    const jsonSchema = zuiToJsonSchema(arrayWithObjects, { target: 'openApi3' })
+    const jsonSchema = toJsonSchemaLegacy(arrayWithObjects, { target: 'openApi3' })
     expect(jsonSchema).toEqual({
       description: 'Array of objects with validation',
       items: {
@@ -207,7 +207,7 @@ describe('zuiToJsonSchema', () => {
       z.object({ kek: z.literal('B'), lel: z.number() }),
     ])
 
-    const jsonSchema = zuiToJsonSchema(schema)
+    const jsonSchema = toJsonSchemaLegacy(schema)
     expect(jsonSchema).toEqual({
       anyOf: [
         {
@@ -255,7 +255,7 @@ describe('zuiToJsonSchema', () => {
       z.object({ kek: z.literal('B'), lel: z.number() }),
     ])
 
-    const jsonSchema = zuiToJsonSchema(schema, { target: 'openApi3', discriminator: true, unionStrategy: 'oneOf' })
+    const jsonSchema = toJsonSchemaLegacy(schema, { target: 'openApi3', discriminator: true, unionStrategy: 'oneOf' })
     expect(jsonSchema).toEqual({
       discriminator: {
         propertyName: 'kek',
@@ -308,7 +308,7 @@ describe('zuiToJsonSchema', () => {
       }),
     )
 
-    const zSchema = zuiToJsonSchema(schema)
+    const zSchema = toJsonSchemaLegacy(schema)
     expect(zSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -334,7 +334,7 @@ describe('zuiToJsonSchema', () => {
   test('array of array', () => {
     const schema = z.array(z.array(z.string().disabled()))
 
-    const jsonSchema = zuiToJsonSchema(schema)
+    const jsonSchema = toJsonSchemaLegacy(schema)
     expect(jsonSchema).toEqual({
       items: {
         items: {
@@ -353,7 +353,7 @@ describe('zuiToJsonSchema', () => {
 
   test('generic is transformed to a ref', () => {
     const T = z.ref('T').disabled()
-    const TJsonSchema = zuiToJsonSchema(T)
+    const TJsonSchema = toJsonSchemaLegacy(T)
     expect(TJsonSchema).toEqual({
       $ref: 'T',
       [zuiKey]: {
@@ -366,7 +366,7 @@ describe('zuiToJsonSchema', () => {
       data: T,
     })
 
-    const jsonSchema = zuiToJsonSchema(schema)
+    const jsonSchema = toJsonSchemaLegacy(schema)
     expect(jsonSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -392,7 +392,7 @@ describe('coercion serialization', () => {
   {
     it('serializes coerced dates correctly', () => {
       const schema = z.coerce.date().displayAs({ id: 'doood', params: {} } as never)
-      const serialized = zuiToJsonSchema(schema)
+      const serialized = toJsonSchemaLegacy(schema)
       expect(serialized).toEqual({
         format: 'date-time',
         type: 'string',
@@ -405,7 +405,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced strings correctly', () => {
       const schema = z.coerce.string()
-      const serialized = zuiToJsonSchema(schema)
+      const serialized = toJsonSchemaLegacy(schema)
       expect(serialized).toEqual({
         type: 'string',
         [zuiKey]: {
@@ -416,7 +416,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced bigints correctly', () => {
       const schema = z.coerce.bigint()
-      const serialized = zuiToJsonSchema(schema)
+      const serialized = toJsonSchemaLegacy(schema)
       expect(serialized).toEqual({
         format: 'int64',
         type: 'integer',
@@ -428,7 +428,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced booleans correctly', () => {
       const schema = z.coerce.boolean()
-      const serialized = zuiToJsonSchema(schema)
+      const serialized = toJsonSchemaLegacy(schema)
       expect(serialized).toEqual({
         type: 'boolean',
         [zuiKey]: {
@@ -439,7 +439,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced numbers correctly', () => {
       const schema = z.coerce.number()
-      const serialized = zuiToJsonSchema(schema)
+      const serialized = toJsonSchemaLegacy(schema)
       expect(serialized).toEqual({
         type: 'number',
         [zuiKey]: {

--- a/zui/src/transforms/zui-to-json-schema/zui-extension.test.ts
+++ b/zui/src/transforms/zui-to-json-schema/zui-extension.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, it } from 'vitest'
-import { toJsonSchemaLegacy } from './zui-extension'
+import { toJSONSchemaLegacy } from './zui-extension'
 import { z } from '../../z/index'
 import { zuiKey } from '../../ui/constants'
 
@@ -10,7 +10,7 @@ describe('zuiToJsonSchema', () => {
       age: z.number().max(100).min(0).title('Age').describe('Age in years').default(20),
     })
 
-    const jsonSchema = toJsonSchemaLegacy(schema)
+    const jsonSchema = toJSONSchemaLegacy(schema)
 
     expect(jsonSchema).toEqual({
       additionalProperties: false,
@@ -40,7 +40,7 @@ describe('zuiToJsonSchema', () => {
 
   test('enums', () => {
     expect(
-      toJsonSchemaLegacy(
+      toJSONSchemaLegacy(
         z.object({
           fruit: z.enum(['Apple', 'Banana', 'Orange']),
         }),
@@ -68,7 +68,7 @@ describe('zuiToJsonSchema', () => {
         .displayAs({ id: 'customstringcomponent', params: { multiline: true } }),
     })
 
-    const jsonSchema = toJsonSchemaLegacy(schema)
+    const jsonSchema = toJSONSchemaLegacy(schema)
     expect(jsonSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -94,7 +94,7 @@ describe('zuiToJsonSchema', () => {
   test('examples are available on json schema', () => {
     const schema = z.string()
 
-    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: false })
+    const jsonSchema = toJSONSchemaLegacy(schema, { $schemaUrl: false })
     expect(jsonSchema).toEqual({
       type: 'string',
       [zuiKey]: {},
@@ -104,7 +104,7 @@ describe('zuiToJsonSchema', () => {
   test('record with a value works', () => {
     const schema = z.record(z.string().max(30)).describe('hello')
 
-    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: false })
+    const jsonSchema = toJSONSchemaLegacy(schema, { $schemaUrl: false })
     expect(jsonSchema).toEqual({
       additionalProperties: {
         maxLength: 30,
@@ -120,7 +120,7 @@ describe('zuiToJsonSchema', () => {
   test('record with second parameter', () => {
     const schema = z.record(z.string(), z.number().max(30), {}).describe('hello')
 
-    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: false })
+    const jsonSchema = toJSONSchemaLegacy(schema, { $schemaUrl: false })
     expect(jsonSchema).toEqual({
       additionalProperties: {
         maximum: 30,
@@ -136,7 +136,7 @@ describe('zuiToJsonSchema', () => {
   test('record with second parameter', () => {
     const schema = z.object({})
 
-    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: 'http://schema.com' })
+    const jsonSchema = toJSONSchemaLegacy(schema, { $schemaUrl: 'http://schema.com' })
     expect(jsonSchema).toEqual({
       $schema: 'http://schema.com',
       additionalProperties: false,
@@ -149,7 +149,7 @@ describe('zuiToJsonSchema', () => {
   test('record with second parameter', () => {
     const schema = z.object({ multipleTypes: z.union([z.string(), z.number()]) })
 
-    const jsonSchema = toJsonSchemaLegacy(schema, { $schemaUrl: false })
+    const jsonSchema = toJSONSchemaLegacy(schema, { $schemaUrl: false })
     expect(jsonSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -175,7 +175,7 @@ describe('zuiToJsonSchema', () => {
       .min(1)
       .describe('Array of objects with validation')
 
-    const jsonSchema = toJsonSchemaLegacy(arrayWithObjects, { target: 'openApi3' })
+    const jsonSchema = toJSONSchemaLegacy(arrayWithObjects, { target: 'openApi3' })
     expect(jsonSchema).toEqual({
       description: 'Array of objects with validation',
       items: {
@@ -207,7 +207,7 @@ describe('zuiToJsonSchema', () => {
       z.object({ kek: z.literal('B'), lel: z.number() }),
     ])
 
-    const jsonSchema = toJsonSchemaLegacy(schema)
+    const jsonSchema = toJSONSchemaLegacy(schema)
     expect(jsonSchema).toEqual({
       anyOf: [
         {
@@ -255,7 +255,7 @@ describe('zuiToJsonSchema', () => {
       z.object({ kek: z.literal('B'), lel: z.number() }),
     ])
 
-    const jsonSchema = toJsonSchemaLegacy(schema, { target: 'openApi3', discriminator: true, unionStrategy: 'oneOf' })
+    const jsonSchema = toJSONSchemaLegacy(schema, { target: 'openApi3', discriminator: true, unionStrategy: 'oneOf' })
     expect(jsonSchema).toEqual({
       discriminator: {
         propertyName: 'kek',
@@ -308,7 +308,7 @@ describe('zuiToJsonSchema', () => {
       }),
     )
 
-    const zSchema = toJsonSchemaLegacy(schema)
+    const zSchema = toJSONSchemaLegacy(schema)
     expect(zSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -334,7 +334,7 @@ describe('zuiToJsonSchema', () => {
   test('array of array', () => {
     const schema = z.array(z.array(z.string().disabled()))
 
-    const jsonSchema = toJsonSchemaLegacy(schema)
+    const jsonSchema = toJSONSchemaLegacy(schema)
     expect(jsonSchema).toEqual({
       items: {
         items: {
@@ -353,7 +353,7 @@ describe('zuiToJsonSchema', () => {
 
   test('generic is transformed to a ref', () => {
     const T = z.ref('T').disabled()
-    const TJsonSchema = toJsonSchemaLegacy(T)
+    const TJsonSchema = toJSONSchemaLegacy(T)
     expect(TJsonSchema).toEqual({
       $ref: 'T',
       [zuiKey]: {
@@ -366,7 +366,7 @@ describe('zuiToJsonSchema', () => {
       data: T,
     })
 
-    const jsonSchema = toJsonSchemaLegacy(schema)
+    const jsonSchema = toJSONSchemaLegacy(schema)
     expect(jsonSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -392,7 +392,7 @@ describe('coercion serialization', () => {
   {
     it('serializes coerced dates correctly', () => {
       const schema = z.coerce.date().displayAs({ id: 'doood', params: {} } as never)
-      const serialized = toJsonSchemaLegacy(schema)
+      const serialized = toJSONSchemaLegacy(schema)
       expect(serialized).toEqual({
         format: 'date-time',
         type: 'string',
@@ -405,7 +405,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced strings correctly', () => {
       const schema = z.coerce.string()
-      const serialized = toJsonSchemaLegacy(schema)
+      const serialized = toJSONSchemaLegacy(schema)
       expect(serialized).toEqual({
         type: 'string',
         [zuiKey]: {
@@ -416,7 +416,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced bigints correctly', () => {
       const schema = z.coerce.bigint()
-      const serialized = toJsonSchemaLegacy(schema)
+      const serialized = toJSONSchemaLegacy(schema)
       expect(serialized).toEqual({
         format: 'int64',
         type: 'integer',
@@ -428,7 +428,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced booleans correctly', () => {
       const schema = z.coerce.boolean()
-      const serialized = toJsonSchemaLegacy(schema)
+      const serialized = toJSONSchemaLegacy(schema)
       expect(serialized).toEqual({
         type: 'boolean',
         [zuiKey]: {
@@ -439,7 +439,7 @@ describe('coercion serialization', () => {
 
     it('serializes coerced numbers correctly', () => {
       const schema = z.coerce.number()
-      const serialized = toJsonSchemaLegacy(schema)
+      const serialized = toJSONSchemaLegacy(schema)
       expect(serialized).toEqual({
         type: 'number',
         [zuiKey]: {

--- a/zui/src/transforms/zui-to-json-schema/zui-extension.ts
+++ b/zui/src/transforms/zui-to-json-schema/zui-extension.ts
@@ -22,7 +22,7 @@ export type ZuiSchemaOptions = {
  *
  * @deprecated Use the new toJsonSchema function instead.
  */
-export const zuiToJsonSchema = (
+export const toJsonSchemaLegacy = (
   zuiType: z.ZodTypeAny,
   opts: ZuiSchemaOptions = { target: 'openApi3' },
 ): JSONSchema7 => {

--- a/zui/src/transforms/zui-to-json-schema/zui-extension.ts
+++ b/zui/src/transforms/zui-to-json-schema/zui-extension.ts
@@ -20,9 +20,9 @@ export type ZuiSchemaOptions = {
 /**
  * Converts a Zod schema to a JSON Schema.
  *
- * @deprecated Use the new toJsonSchema function instead.
+ * @deprecated Use the new toJSONSchema function instead.
  */
-export const toJsonSchemaLegacy = (
+export const toJSONSchemaLegacy = (
   zuiType: z.ZodTypeAny,
   opts: ZuiSchemaOptions = { target: 'openApi3' },
 ): JSONSchema7 => {

--- a/zui/src/z/types/basetype/index.ts
+++ b/zui/src/z/types/basetype/index.ts
@@ -44,8 +44,8 @@ import {
 import { CatchFn } from '../catch'
 import { toTypescriptType, TypescriptGenerationOptions } from '../../../transforms/zui-to-typescript-type'
 import { toTypescriptSchema } from '../../../transforms/zui-to-typescript-schema'
-import { toJsonSchema } from '../../../transforms/zui-to-json-schema-next'
-import { ZuiJsonSchema } from '../../../transforms/common/json-schema'
+import { toJSONSchema } from '../../../transforms/zui-to-json-schema-next'
+import { ZuiJSONSchema } from '../../../transforms/common/json-schema'
 
 /**
  * This type is not part of the original Zod library, it's been added in Zui to:
@@ -624,8 +624,8 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
    *
    * @returns a JSON Schema equivalent to the Zui schema
    */
-  toJsonSchema(): ZuiJsonSchema {
-    return toJsonSchema(this)
+  toJSONSchema(): ZuiJSONSchema {
+    return toJSONSchema(this)
   }
 
   /**


### PR DESCRIPTION
I renamed most occurrences of `Json` to `JSON` so the casing can be the exact same as zod v4: https://zod.dev/v4?id=json-schema-conversion