### PR TITLE
chore(gravity): configure rust toolchain

### DIFF
--- a/.github/workflows/gravity.yml
+++ b/.github/workflows/gravity.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           node-version: '22.17.0'
           check-latest: true
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm check:type

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 pnpm 8.6.2
 nodejs 22.17.0
+rust stable

--- a/gravity/package.json
+++ b/gravity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/gravity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Generic density-based clustering (UMAP + HDBSCAN), compiled from Rust to WebAssembly.",
   "main": "./dist/node/index.js",
   "module": "./dist/web/index.js",


### PR DESCRIPTION
## Summary

- Add Rust to the repo-level mise-compatible `.tool-versions` file.
- Remove the duplicate Gravity workflow Rust setup step so CI uses the repo toolchain configuration.
- Bump `@bpinternal/gravity` to `0.1.1`.

## Validation

- `git diff --check`
- `pnpm check` in `gravity`
- `pnpm test` in `gravity`
- `pnpm build` in `gravity`