### PR TITLE
feat(thicktoken): Cloudflare Workers (workerd) support

### DIFF
--- a/thicktoken/package.json
+++ b/thicktoken/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/thicktoken",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A bundled cl100k tokenizer (Rust→WASM) with count/truncate/split helpers",
   "repository": {
     "url": "https://github.com/botpress/packages"
@@ -15,19 +15,29 @@
   "exports": {
     ".": {
       "types": "./dist/tokenizer.d.ts",
+      "workerd": "./dist/micro.workerd.mjs",
       "import": "./dist/tokenizer.mjs",
       "require": "./dist/tokenizer.js"
     },
     "./lite": {
       "types": "./dist/lite.d.ts",
+      "workerd": "./dist/lite.workerd.mjs",
       "import": "./dist/lite.mjs",
       "require": "./dist/lite.js"
     },
     "./micro": {
       "types": "./dist/micro.d.ts",
+      "workerd": "./dist/micro.workerd.mjs",
       "import": "./dist/micro.mjs",
       "require": "./dist/micro.js"
-    }
+    },
+    "./full": {
+      "types": "./dist/tokenizer.d.ts",
+      "workerd": "./dist/tokenizer.workerd.mjs",
+      "import": "./dist/tokenizer.mjs",
+      "require": "./dist/tokenizer.js"
+    },
+    "./engine.wasm": "./dist/thicktoken_wasm_bg.wasm"
   },
   "keywords": [],
   "author": "",

--- a/thicktoken/readme.md
+++ b/thicktoken/readme.md
@@ -26,6 +26,33 @@ Truncated variants only ever **overcount** — safe for budget enforcement (they
 more, never overflow a window). Do **not** use them for billing math or exact window
 packing; inflation is content-dependent (worst on emoji/unicode-dense text).
 
+## Cloudflare Workers (workerd)
+
+workerd bans runtime WASM compilation (`new WebAssembly.Module(bytes)`), so the default
+builds — which inline the engine WASM as base64 and compile it at import time — can't run
+there. Two mechanisms handle this:
+
+1. **`workerd` export condition (zero-config).** Bundlers/runtimes that honor the
+   `workerd` condition (wrangler does) resolve every entry to a `*.workerd.mjs` build in
+   which the engine `.wasm` ships as a **separate dist file** and stays a **static
+   import** — workerd compiles it at deploy time and hands the module to `initSync`
+   precompiled. On workerd, the root `@bpinternal/thicktoken` entry resolves to the
+   **micro** (cl25k) asset — the smallest footprint, and prompt budgeting doesn't need
+   exact cl100k counts. Use `@bpinternal/thicktoken/full` if you really need exact cl100k
+   counts on Workers.
+
+2. **`getWasmTokenizer({ wasmModule })` (explicit injection).** Pass your own precompiled
+   `WebAssembly.Module` (e.g. from a static `.wasm` import) and the engine skips runtime
+   compilation entirely:
+
+   ```ts
+   import { getWasmTokenizer } from '@bpinternal/thicktoken/micro'
+   import wasmModule from '@bpinternal/thicktoken/engine.wasm' // static import
+   const tokenizer = await getWasmTokenizer({ wasmModule })
+   ```
+
+The vocab `.gz` assets are plain data (inflated inside the WASM engine) and stay inlined
+in every build — only the engine `.wasm` needs the special handling.
 
 ## Disclaimer ⚠️
 

--- a/thicktoken/src/core.ts
+++ b/thicktoken/src/core.ts
@@ -1,4 +1,4 @@
-import { WasmTokenizer, type CountOptions, type TruncateMode } from '../wasm/index'
+import { WasmTokenizer, type CountOptions, type CreateOptions, type TruncateMode } from '../wasm/index'
 import { deepClone, mapValues, uniq } from './utils'
 
 export class TokenCollection {
@@ -141,6 +141,8 @@ export class TextTokenizer {
   }
 }
 
+export type GetTokenizerOptions = CreateOptions
+
 /**
  * Builds a memoized async `getWasmTokenizer` for a specific vocab asset. Each
  * package entry (`.` full cl100k, `./lite` cl50k, `./micro` cl25k) bundles its
@@ -148,12 +150,12 @@ export class TextTokenizer {
  */
 export const makeGetTokenizer = (assetGz: Uint8Array) => {
   let tokenizer: TextTokenizer | null = null
-  return async (): Promise<TextTokenizer> => {
+  return async (options: GetTokenizerOptions = {}): Promise<TextTokenizer> => {
     if (!tokenizer) {
-      tokenizer = new TextTokenizer(WasmTokenizer.create(assetGz))
+      tokenizer = new TextTokenizer(WasmTokenizer.create(assetGz, options))
     }
     return tokenizer
   }
 }
 
-export { WasmTokenizer, type CountOptions, type TruncateMode }
+export { WasmTokenizer, type CountOptions, type CreateOptions, type TruncateMode }

--- a/thicktoken/src/lite.ts
+++ b/thicktoken/src/lite.ts
@@ -8,4 +8,11 @@ import { makeGetTokenizer } from './core'
 
 export const getWasmTokenizer = makeGetTokenizer(cl50k)
 
-export { TextTokenizer, TokenCollection, WasmTokenizer, type CountOptions, type TruncateMode } from './core'
+export {
+  TextTokenizer,
+  TokenCollection,
+  WasmTokenizer,
+  type CountOptions,
+  type GetTokenizerOptions,
+  type TruncateMode,
+} from './core'

--- a/thicktoken/src/micro.ts
+++ b/thicktoken/src/micro.ts
@@ -9,4 +9,11 @@ import { makeGetTokenizer } from './core'
 
 export const getWasmTokenizer = makeGetTokenizer(cl25k)
 
-export { TextTokenizer, TokenCollection, WasmTokenizer, type CountOptions, type TruncateMode } from './core'
+export {
+  TextTokenizer,
+  TokenCollection,
+  WasmTokenizer,
+  type CountOptions,
+  type GetTokenizerOptions,
+  type TruncateMode,
+} from './core'

--- a/thicktoken/src/tokenizer.ts
+++ b/thicktoken/src/tokenizer.ts
@@ -9,4 +9,11 @@ import { makeGetTokenizer } from './core'
 
 export const getWasmTokenizer = makeGetTokenizer(cl100k)
 
-export { TextTokenizer, TokenCollection, WasmTokenizer, type CountOptions, type TruncateMode } from './core'
+export {
+  TextTokenizer,
+  TokenCollection,
+  WasmTokenizer,
+  type CountOptions,
+  type GetTokenizerOptions,
+  type TruncateMode,
+} from './core'

--- a/thicktoken/src/wasm-module-injection.test.ts
+++ b/thicktoken/src/wasm-module-injection.test.ts
@@ -1,0 +1,22 @@
+/**
+ * `getWasmTokenizer({ wasmModule })` — injecting a precompiled engine module, for
+ * runtimes that ban runtime WASM compilation (`new WebAssembly.Module(bytes)`),
+ * e.g. Cloudflare Workers. Kept in its own file: vitest isolates test files, so
+ * the engine is guaranteed uninitialized when the injected module is passed —
+ * `initSync` receives the `WebAssembly.Module` and skips runtime compilation.
+ */
+import { describe, it, expect } from 'vitest'
+// @ts-ignore - resolved by the *.wasm module declaration (raw bytes via the vitest inline-wasm plugin)
+import wasmBytes from '../wasm/pkg/thicktoken_wasm_bg.wasm'
+import { getWasmTokenizer } from './micro'
+
+describe('wasmModule injection', () => {
+  it('initializes the engine from a precompiled WebAssembly.Module', async () => {
+    const wasmModule = new WebAssembly.Module(wasmBytes as Uint8Array)
+    const tokenizer = await getWasmTokenizer({ wasmModule })
+
+    expect(tokenizer.count('Hello, world!', { approximate: false })).toBeGreaterThanOrEqual(4)
+    expect(tokenizer.truncate('one two three four', 2)).toBe('one two')
+    expect(tokenizer.split('Hello').join('')).toBe('Hello')
+  })
+})

--- a/thicktoken/tsup.config.ts
+++ b/thicktoken/tsup.config.ts
@@ -1,41 +1,70 @@
 // tsup.config.ts
-import { defineConfig } from 'tsup'
+import { defineConfig, type Options } from 'tsup'
 import { readFileSync } from 'fs'
 
-export default defineConfig({
-  entry: ['src/tokenizer.ts', 'src/lite.ts', 'src/micro.ts'],
-  format: ['cjs', 'esm'],
-  platform: 'neutral',
-  clean: true,
-  bundle: true,
-  dts: true,
-  shims: true,
-  cjsInterop: true,
-  esbuildPlugins: [
-    {
-      name: 'inline-binary', // inlines .wasm (engine code) and .gz (vocab assets) as bytes
-      setup(build) {
-        build.onLoad({ filter: /\.(wasm|gz)$/ }, async (args) => {
-          const data = readFileSync(args.path)
-          const base64 = data.toString('base64')
+// Inlines binary assets as bytes, decoded from base64 at import time.
+// Universal base64 decode: Buffer on Node, atob in browsers.
+const inlineBinaryPlugin = (filter: RegExp): NonNullable<Options['esbuildPlugins']>[number] => ({
+  name: 'inline-binary',
+  setup(build) {
+    build.onLoad({ filter }, async (args) => {
+      const data = readFileSync(args.path)
+      const base64 = data.toString('base64')
 
-          // Universal base64 decode: Buffer on Node, atob in browsers.
-          const contents = `
-            // Inlined WASM file as base64
-            const wasmBase64 = "${base64}";
-            let bytes;
-            if (typeof Buffer !== 'undefined') {
-              bytes = Buffer.from(wasmBase64, 'base64');
-            } else {
-              const bin = atob(wasmBase64);
-              bytes = new Uint8Array(bin.length);
-              for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-            }
-            export default bytes;
-        `
-          return { contents, loader: 'js' }
-        })
-      }
-    }
-  ]
+      const contents = `
+        // Inlined binary file as base64
+        const wasmBase64 = "${base64}";
+        let bytes;
+        if (typeof Buffer !== 'undefined') {
+          bytes = Buffer.from(wasmBase64, 'base64');
+        } else {
+          const bin = atob(wasmBase64);
+          bytes = new Uint8Array(bin.length);
+          for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        }
+        export default bytes;
+    `
+      return { contents, loader: 'js' }
+    })
+  },
 })
+
+export default defineConfig([
+  // Default build: everything inlined (engine .wasm + vocab .gz) so the package
+  // works everywhere without path resolution — Node, browsers, bundlers, Lambda.
+  {
+    entry: ['src/tokenizer.ts', 'src/lite.ts', 'src/micro.ts'],
+    format: ['cjs', 'esm'],
+    platform: 'neutral',
+    clean: true,
+    bundle: true,
+    dts: true,
+    shims: true,
+    cjsInterop: true,
+    esbuildPlugins: [inlineBinaryPlugin(/\.(wasm|gz)$/)],
+  },
+  // Workerd (Cloudflare Workers) build: runtime WASM compilation is banned there,
+  // so the engine .wasm ships as a separate dist file and stays a static import —
+  // the runtime compiles it at deploy time and the module resolves to a
+  // precompiled WebAssembly.Module. Vocab .gz assets are plain data and stay inlined.
+  {
+    entry: {
+      'tokenizer.workerd': 'src/tokenizer.ts',
+      'lite.workerd': 'src/lite.ts',
+      'micro.workerd': 'src/micro.ts',
+    },
+    format: ['esm'],
+    platform: 'neutral',
+    clean: false,
+    bundle: true,
+    dts: false,
+    shims: false,
+    loader: { '.wasm': 'copy' },
+    esbuildOptions(options) {
+      // Stable (unhashed) filename so the engine module is importable at a fixed
+      // path (exported as "./engine.wasm") for explicit wasmModule injection.
+      options.assetNames = '[name]'
+    },
+    esbuildPlugins: [inlineBinaryPlugin(/\.gz$/)],
+  },
+])

--- a/thicktoken/wasm/index.ts
+++ b/thicktoken/wasm/index.ts
@@ -21,7 +21,19 @@ import wasmBinary from './pkg/thicktoken_wasm_bg.wasm'
 let initialized = false
 const ensureInit = (wasmModule?: WebAssembly.Module) => {
   if (!initialized) {
-    initSync({ module: wasmModule ?? wasmBinary })
+    const module = wasmModule ?? wasmBinary
+    if (typeof (module as unknown) === 'string') {
+      // A bundler lowered the .wasm import to an asset-path string (e.g. esbuild's
+      // `file` loader). Fail with a clear message instead of the cryptic type error
+      // `new WebAssembly.Module(<string>)` would produce.
+      throw new Error(
+        'thicktoken: the engine .wasm import resolved to a path string instead of bytes or a ' +
+          'precompiled WebAssembly.Module. Configure your bundler to inline .wasm imports as ' +
+          'bytes or keep them as native wasm module imports (as workerd does), or inject a ' +
+          'precompiled module explicitly: getWasmTokenizer({ wasmModule }).'
+      )
+    }
+    initSync({ module })
     initialized = true
   }
 }

--- a/thicktoken/wasm/index.ts
+++ b/thicktoken/wasm/index.ts
@@ -11,16 +11,29 @@
  * ../NOTICE. cl100k_base encoding.
  */
 import { initSync, WasmTokenizer as RawTokenizer } from './pkg/thicktoken_wasm.js'
-// Inlined by the build tooling (tsup/vitest inline-wasm plugin) as raw bytes.
+// Default build: inlined by the build tooling (tsup/vitest inline-wasm plugin) as raw
+// bytes, compiled at runtime. Workerd build: emitted as a separate dist .wasm file and
+// statically imported, so the runtime hands us a precompiled WebAssembly.Module
+// (runtime WASM compilation is banned on Cloudflare Workers). initSync accepts both.
 // @ts-ignore - resolved by the *.wasm module declaration
-import wasmBytes from './pkg/thicktoken_wasm_bg.wasm'
+import wasmBinary from './pkg/thicktoken_wasm_bg.wasm'
 
 let initialized = false
-const ensureInit = () => {
+const ensureInit = (wasmModule?: WebAssembly.Module) => {
   if (!initialized) {
-    initSync({ module: wasmBytes })
+    initSync({ module: wasmModule ?? wasmBinary })
     initialized = true
   }
+}
+
+export interface CreateOptions {
+  /**
+   * Precompiled engine module, for runtimes that ban runtime WASM compilation
+   * (`new WebAssembly.Module(bytes)`), e.g. Cloudflare Workers. Build it from a
+   * statically imported `.wasm` file and inject it here. Ignored if the engine
+   * is already initialized.
+   */
+  wasmModule?: WebAssembly.Module
 }
 
 /** Which part of the text to preserve when truncating. */
@@ -42,8 +55,8 @@ export class WasmTokenizer {
    * Build a tokenizer from a gzip'd merges-only asset (one of wasm/assets/*.gz —
    * full cl100k, lite cl50k, or micro cl25k; see wasm/scripts/gen-assets.mjs).
    */
-  static create(assetGz: Uint8Array): WasmTokenizer {
-    ensureInit()
+  static create(assetGz: Uint8Array, options: CreateOptions = {}): WasmTokenizer {
+    ensureInit(options.wasmModule)
     return new WasmTokenizer(new RawTokenizer(assetGz))
   }
 

--- a/thicktoken/wasm/wasm.d.ts
+++ b/thicktoken/wasm/wasm.d.ts
@@ -1,8 +1,10 @@
-// The build tooling (tsup inline-wasm esbuild plugin / vitest inline-wasm vite plugin)
-// turns `.wasm` imports into a module whose default export is the raw bytes.
+// The build tooling turns `.wasm` imports into a module whose default export is
+// the raw bytes (default build: tsup inline-wasm esbuild plugin / vitest
+// inline-wasm vite plugin) or a precompiled WebAssembly.Module (workerd build:
+// esbuild copy loader + the runtime's native .wasm module support).
 declare module '*.wasm' {
-  const bytes: Uint8Array
-  export default bytes
+  const binary: Uint8Array | WebAssembly.Module
+  export default binary
 }
 
 declare module '*.gz' {


### PR DESCRIPTION
## Why

workerd (Cloudflare Workers) bans runtime WASM compilation (`new WebAssembly.Module(bytes)`). All three thicktoken entries inline the engine WASM as base64 and compile it at import time, so the package cannot load on Workers today. This blocks running llmz natively on Workers (prompt budgeting uses thicktoken).

## What

Mirrors quickjs-emscripten's pattern, two mechanisms:

### 1. `workerd` export condition (zero-config)

A second tsup build emits `tokenizer.workerd.mjs` / `lite.workerd.mjs` / `micro.workerd.mjs` where the engine `.wasm` ships as a **separate dist file** (`dist/thicktoken_wasm_bg.wasm`, unhashed) and stays a **static import** — workerd compiles it at deploy time and `initSync` receives a precompiled `WebAssembly.Module` (wasm-bindgen's `initSync` already handles that natively; it only calls `new WebAssembly.Module` when handed raw bytes).

Bundlers/runtimes honoring the `workerd` condition (wrangler does) resolve these automatically:

- `.` → **micro (cl25k) build** on workerd — smallest footprint (~137KB entry + 385KB wasm), and prompt budgeting doesn't need exact cl100k counts
- `./lite`, `./micro` → their respective workerd builds
- new `./full` subpath keeps exact cl100k reachable on Workers

Vocab `.gz` assets are plain data (gunzipped inside the engine, no code generation) and stay inlined in every build — only the engine `.wasm` needs special handling.

### 2. Explicit injection: `getWasmTokenizer({ wasmModule })`

For consumers who don't get the export condition, a precompiled module can be injected directly (new `./engine.wasm` subpath provides a stable static-import path):

```ts
import { getWasmTokenizer } from '@bpinternal/thicktoken/micro'
import wasmModule from '@bpinternal/thicktoken/engine.wasm'
const tokenizer = await getWasmTokenizer({ wasmModule })
```

## Notes

- Version bumped 3.0.0 → 3.1.0. Default builds are byte-for-byte unchanged in behavior; the API addition is backwards-compatible (`getWasmTokenizer()` with no args works as before).
- New isolated test file exercises the `wasmModule` injection path (vitest per-file isolation guarantees the engine is uninitialized when the module is injected).
- 73/73 tests pass, typecheck clean.
- Counterpart llmz changes (branch `sly/llmz-cloudflare-workers` in botpress/botpress): `configureTokenizer()` / `configureQuickJS()` injection points and no more Node-driver fallback on workerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)