### PR TITLE
feat(tunnel): bridge public WebSockets over the tunnel

### DIFF
--- a/tunnel/e2e/index.ts
+++ b/tunnel/e2e/index.ts
@@ -2,6 +2,7 @@ import { Logger } from '@bpinternal/log4bot'
 import yargs, { YargsArgv, YargsSchema } from '@bpinternal/yargs-extra'
 import * as browser from './browser'
 import * as nodejs from './nodejs'
+import * as websocket from './websocket'
 import { sleep } from './utils'
 
 const tests = [
@@ -19,6 +20,16 @@ const tests = [
     name: 'nodejs-invalid-request',
     port: 9082,
     test: nodejs.testInvalidRequest
+  },
+  {
+    name: 'websocket-bridge',
+    port: 9083,
+    test: websocket.testWebSocketBridge
+  },
+  {
+    name: 'websocket-unsupported',
+    port: 9084,
+    test: websocket.testWebSocketUnsupported
   }
 ]
 

--- a/tunnel/e2e/index.ts
+++ b/tunnel/e2e/index.ts
@@ -30,6 +30,11 @@ const tests = [
     name: 'websocket-unsupported',
     port: 9084,
     test: websocket.testWebSocketUnsupported
+  },
+  {
+    name: 'websocket-pending-cap',
+    port: 9085,
+    test: websocket.testWebSocketPendingCap
   }
 ]
 

--- a/tunnel/e2e/websocket.ts
+++ b/tunnel/e2e/websocket.ts
@@ -1,0 +1,89 @@
+import { Logger } from '@bpinternal/log4bot'
+import WebSocket from 'isomorphic-ws'
+import { TunnelTail, TunnelServer } from '../src'
+import { CLOSE_CODES } from '../src/errors'
+import { expect } from './utils'
+
+const TUNNEL_ID = 'ws-tunnel-id'
+
+/**
+ * A visitor WebSocket dialed against `/:tunnelId/:path` bridges through the
+ * tunnel: the tail sees ws_open with the visitor's path/query, frames relay
+ * in both directions, and a visitor close reaches the tail.
+ */
+export const testWebSocketBridge = async (port: number, logger: Logger) => {
+  const server = await TunnelServer.new({ port })
+  const tunnelTail = await TunnelTail.new(`ws://localhost:${port}`, TUNNEL_ID)
+
+  // The tail acts as the local endpoint: accept every ws_open, echo every
+  // frame back with a prefix, and record the close.
+  const opened = new Promise<{ path: string; query?: string }>((resolve) => {
+    tunnelTail.events.on('ws_open', (msg) => {
+      logger.debug(`tail ws_open: ${JSON.stringify(msg)}`)
+      tunnelTail.acceptWebSocket(msg.id)
+      resolve({ path: msg.path, ...(msg.query !== undefined && { query: msg.query }) })
+    })
+  })
+  tunnelTail.events.on('ws_frame', (msg) => {
+    logger.debug(`tail ws_frame: ${JSON.stringify(msg)}`)
+    tunnelTail.sendWebSocketFrame(msg.id, `echo:${msg.data}`, msg.binary)
+  })
+  const tailSawClose = new Promise<{ code?: number }>((resolve) => {
+    tunnelTail.events.on('ws_close', (msg) => resolve({ code: msg.code }))
+  })
+
+  // The tail must advertise the ws capability before the visitor connects
+  // (its hello is sent on open; wait for the head to have processed it).
+  const head = server.getTunnel(TUNNEL_ID)
+  if (!head) throw new Error(`Tunnel ${TUNNEL_ID} not found`)
+  for (let i = 0; i < 50 && !head.supportsWebSockets; i++) {
+    await new Promise((r) => setTimeout(r, 20))
+  }
+  expect(String(head.supportsWebSockets)).toBe('true')
+
+  const visitor = new WebSocket(`ws://localhost:${port}/${TUNNEL_ID}/edge/bots/b1/conversations/c1/ws?token=t1`)
+  const received: string[] = []
+  const gotEcho = new Promise<string>((resolve) => {
+    visitor.addEventListener('message', (ev: WebSocket.MessageEvent) => {
+      received.push(ev.data.toString())
+      resolve(ev.data.toString())
+    })
+  })
+  // Send before the tail accepts on purpose — the server must buffer it.
+  visitor.addEventListener('open', () => visitor.send('hello-through-tunnel'))
+
+  const { path, query } = await opened
+  expect(path).toBe('/edge/bots/b1/conversations/c1/ws')
+  expect(query ?? '').toBe('token=t1')
+
+  const echoed = await gotEcho
+  expect(echoed).toBe('echo:hello-through-tunnel')
+
+  visitor.close(1000, 'done')
+  await tailSawClose
+
+  tunnelTail.close()
+  server.close()
+}
+
+/** A visitor upgrading against a tail that never advertised `ws` is refused cleanly. */
+export const testWebSocketUnsupported = async (port: number, _logger: Logger) => {
+  const server = await TunnelServer.new({ port })
+  const tunnelTail = await TunnelTail.new(`ws://localhost:${port}`, TUNNEL_ID)
+
+  const head = server.getTunnel(TUNNEL_ID)
+  if (!head) throw new Error(`Tunnel ${TUNNEL_ID} not found`)
+  // Simulate a pre-websocket tail: let the on-open hello land, then wipe the
+  // advertised capability (wiping first would race the hello repopulating it).
+  for (let i = 0; i < 50 && !head.supportsWebSockets; i++) {
+    await new Promise((r) => setTimeout(r, 20))
+  }
+  ;(head as unknown as { _capabilities: Set<string> })._capabilities = new Set()
+
+  const visitor = new WebSocket(`ws://localhost:${port}/${TUNNEL_ID}/some/path`)
+  const closed = await new Promise<WebSocket.CloseEvent>((resolve) => visitor.addEventListener('close', resolve))
+  expect(String(closed.code)).toBe(String(CLOSE_CODES.WS_UNSUPPORTED))
+
+  tunnelTail.close()
+  server.close()
+}

--- a/tunnel/e2e/websocket.ts
+++ b/tunnel/e2e/websocket.ts
@@ -66,6 +66,31 @@ export const testWebSocketBridge = async (port: number, logger: Logger) => {
   server.close()
 }
 
+/** Pre-accept frames are hard-capped: a visitor flooding before the tail accepts is closed with 1009. */
+export const testWebSocketPendingCap = async (port: number, _logger: Logger) => {
+  const server = await TunnelServer.new({ port })
+  const tunnelTail = await TunnelTail.new(`ws://localhost:${port}`, TUNNEL_ID)
+  // Never accept — every visitor frame lands in the pre-accept buffer.
+  tunnelTail.events.on('ws_open', () => {})
+
+  const head = server.getTunnel(TUNNEL_ID)
+  if (!head) throw new Error(`Tunnel ${TUNNEL_ID} not found`)
+  for (let i = 0; i < 50 && !head.supportsWebSockets; i++) {
+    await new Promise((r) => setTimeout(r, 20))
+  }
+
+  const visitor = new WebSocket(`ws://localhost:${port}/${TUNNEL_ID}/flood`)
+  const closed = new Promise<WebSocket.CloseEvent>((resolve) => visitor.addEventListener('close', resolve))
+  visitor.addEventListener('open', () => {
+    for (let i = 0; i < 100; i++) visitor.send(`frame-${i}`)
+  })
+  const { code } = await closed
+  expect(String(code)).toBe('1009')
+
+  tunnelTail.close()
+  server.close()
+}
+
 /** A visitor upgrading against a tail that never advertised `ws` is refused cleanly. */
 export const testWebSocketUnsupported = async (port: number, _logger: Logger) => {
   const server = await TunnelServer.new({ port })

--- a/tunnel/package.json
+++ b/tunnel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/tunnel",
-  "version": "0.1.25",
+  "version": "0.2.0",
   "description": "Tunneling logic for client and server",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.mjs",

--- a/tunnel/src/errors.ts
+++ b/tunnel/src/errors.ts
@@ -6,6 +6,7 @@ export const CLOSE_CODES = {
   INVALID_REQUEST_PAYLOAD: 4003,
   INTERNAL_TAIL_ERROR: 4004,
   INTERNAL_HEAD_ERROR: 4005,
+  WS_UNSUPPORTED: 4006,
 } as const
 
 export class TunnelError extends Error {

--- a/tunnel/src/rooting.ts
+++ b/tunnel/src/rooting.ts
@@ -1,4 +1,5 @@
 const URL_REGEX = /^\/([\w|-]+)$/ // /:tunnelId
+const PUBLIC_URL_REGEX = /^\/([\w|-]+)(\/[^?]*)(?:\?(.*))?$/ // /:tunnelId/:path[?query]
 
 export const formatUrl = (host: string, tunnelId: string): string => {
   return `${host}/${tunnelId}`
@@ -26,4 +27,37 @@ export const parseUrl = (url: string | undefined): ParseUrlResult => {
 
   const tunnelId = match[1] as string
   return { status: 'success', tunnelId }
+}
+
+type ParsePublicUrlResult =
+  | {
+      status: 'error'
+      reason: string
+    }
+  | {
+      status: 'success'
+      tunnelId: string
+      path: string
+      query?: string
+    }
+
+/**
+ * A public visitor URL: the tunnel id followed by the path the visitor
+ * targets on the tail (`/:tunnelId/:path[?query]`). Distinct from the
+ * bare `/:tunnelId` a tail registers with.
+ */
+export const parsePublicUrl = (url: string | undefined): ParsePublicUrlResult => {
+  if (!url) {
+    return { status: 'error', reason: 'url is empty' }
+  }
+
+  const match = url.match(PUBLIC_URL_REGEX)
+  if (!match) {
+    return { status: 'error', reason: 'invalid url' }
+  }
+
+  const tunnelId = match[1] as string
+  const path = match[2] as string
+  const query = match[3] as string | undefined
+  return { status: 'success', tunnelId, path, ...(query !== undefined && { query }) }
 }

--- a/tunnel/src/tunnel-client.ts
+++ b/tunnel/src/tunnel-client.ts
@@ -193,9 +193,9 @@ export class TunnelTail extends TunnelClient {
   }
 
   /** Confirm a `ws_open` — frames may flow for this connection from now on. */
-  public readonly acceptWebSocket = (id: string, subprotocol?: string) => {
+  public readonly acceptWebSocket = (id: string) => {
     this._throwIfClosed()
-    const accept: TunnelWsAccept = { type: 'ws_accept', id, ...(subprotocol && { subprotocol }) }
+    const accept: TunnelWsAccept = { type: 'ws_accept', id }
     this._ws.send(JSON.stringify(accept))
   }
 

--- a/tunnel/src/tunnel-client.ts
+++ b/tunnel/src/tunnel-client.ts
@@ -3,7 +3,19 @@ import WebSocket from 'isomorphic-ws'
 import * as errors from './errors'
 import { EventEmitter } from './event-emitter'
 import * as rooting from './rooting'
-import { Hello, TunnelRequest, TunnelResponse, headSchema, tailSchema } from './types'
+import {
+  Hello,
+  TunnelRequest,
+  TunnelResponse,
+  TunnelWsAccept,
+  TunnelWsClose,
+  TunnelWsFrame,
+  TunnelWsOpen,
+  TunnelWsReject,
+  WS_CAPABILITY,
+  headSchema,
+  tailSchema
+} from './types'
 
 export type ClientCloseEvent = WebSocket.CloseEvent
 export type ClientErrorEvent = WebSocket.Event
@@ -18,7 +30,12 @@ export abstract class TunnelClient {
     open: WebSocket.Event
     request: TunnelRequest
     response: TunnelResponse
-    hello: {}
+    hello: Hello
+    ws_open: TunnelWsOpen
+    ws_accept: TunnelWsAccept
+    ws_reject: TunnelWsReject
+    ws_frame: TunnelWsFrame
+    ws_close: TunnelWsClose
   }>()
 
   public get closed() {
@@ -61,10 +78,29 @@ export abstract class TunnelClient {
     this._ws.close(code ?? errors.CLOSE_CODES.NORMAL_CLOSURE, reason)
   }
 
-  public readonly hello = () => {
+  public readonly hello = (capabilities?: string[]) => {
     this._throwIfClosed()
-    const hello: Hello = { type: 'hello' }
+    const hello: Hello = { type: 'hello', ...(capabilities?.length && { capabilities }) }
     this._ws.send(JSON.stringify(hello))
+  }
+
+  /** Relay one WebSocket frame of the bridged connection `id`. */
+  public readonly sendWebSocketFrame = (id: string, data: string, binary?: boolean) => {
+    this._throwIfClosed()
+    const frame: TunnelWsFrame = { type: 'ws_frame', id, data, ...(binary && { binary }) }
+    this._ws.send(JSON.stringify(frame))
+  }
+
+  /** Close the bridged WebSocket connection `id` on the other end. */
+  public readonly closeWebSocket = (id: string, code?: number, reason?: string) => {
+    this._throwIfClosed()
+    const close: TunnelWsClose = {
+      type: 'ws_close',
+      id,
+      ...(code !== undefined && { code }),
+      ...(reason !== undefined && { reason })
+    }
+    this._ws.send(JSON.stringify(close))
   }
 
   protected _throwIfClosed = () => {
@@ -88,7 +124,10 @@ export class TunnelTail extends TunnelClient {
     error: ClientErrorEvent
     request: TunnelRequest
     open: ClientOpenEvent
-    hello: {}
+    hello: Hello
+    ws_open: TunnelWsOpen
+    ws_frame: TunnelWsFrame
+    ws_close: TunnelWsClose
   }> = this._ev
 
   public static new(host: string, tunnelId: string): Promise<TunnelTail> {
@@ -103,11 +142,30 @@ export class TunnelTail extends TunnelClient {
     const url = rooting.formatUrl(host, tunnelId)
 
     const headers = { 'User-Agent': 'tunnel-client' } // for firewall
+    // The bundled `ws` client throws "Unexpected server response: 101" under
+    // Bun; Bun's native WebSocket handles the upgrade correctly and accepts a
+    // `{ headers }` option, so prefer it there. Keep `ws` under Node.
+    type AnyWebSocketConstructor = new (url: string, options?: unknown) => WebSocket
+    const runtime = globalThis as unknown as { Bun?: unknown; WebSocket?: AnyWebSocketConstructor }
+    const TunnelWS: AnyWebSocketConstructor =
+      runtime.Bun !== undefined && runtime.WebSocket
+        ? runtime.WebSocket
+        : (WebSocket as unknown as AnyWebSocketConstructor)
     const socket = isBrowser
-      ? new WebSocket(url) // headers are not supported in browser, but the browser will add the User-Agent header automatically
-      : new WebSocket(url, { headers })
+      ? new TunnelWS(url) // headers are not supported in browser, but the browser will add the User-Agent header automatically
+      : new TunnelWS(url, { headers })
 
     super(socket)
+
+    // Advertise protocol extensions as soon as the tunnel opens — the head
+    // only bridges visitor WebSockets to tails that declared support.
+    this._ev.once('open', () => {
+      try {
+        this.hello([WS_CAPABILITY])
+      } catch {
+        // The tunnel closed between open and hello — nothing to advertise.
+      }
+    })
 
     this._ev.on('message', (ev: WebSocket.MessageEvent) => {
       const message = this._parseMessage(ev)
@@ -116,10 +174,14 @@ export class TunnelTail extends TunnelClient {
         return
       }
       if (message.type === 'hello') {
-        this.events.emit('hello', {})
+        this.events.emit('hello', message.hello)
         return
       }
-      this.events.emit('request', message.request)
+      if (message.type === 'request') {
+        this.events.emit('request', message.request)
+        return
+      }
+      this.events.emit(message.message.type, message.message as never)
     })
   }
 
@@ -130,9 +192,27 @@ export class TunnelTail extends TunnelClient {
     this._ws.send(JSON.stringify(res))
   }
 
+  /** Confirm a `ws_open` — frames may flow for this connection from now on. */
+  public readonly acceptWebSocket = (id: string, subprotocol?: string) => {
+    this._throwIfClosed()
+    const accept: TunnelWsAccept = { type: 'ws_accept', id, ...(subprotocol && { subprotocol }) }
+    this._ws.send(JSON.stringify(accept))
+  }
+
+  /** Refuse a `ws_open` — the head closes the visitor's socket. */
+  public readonly rejectWebSocket = (id: string, reason?: string) => {
+    this._throwIfClosed()
+    const reject: TunnelWsReject = { type: 'ws_reject', id, ...(reason !== undefined && { reason }) }
+    this._ws.send(JSON.stringify(reject))
+  }
+
   private _parseMessage = (
     ev: WebSocket.MessageEvent
-  ): { type: 'hello' } | { type: 'request'; request: TunnelRequest } | undefined => {
+  ):
+    | { type: 'hello'; hello: Hello }
+    | { type: 'request'; request: TunnelRequest }
+    | { type: 'ws'; message: TunnelWsOpen | TunnelWsFrame | TunnelWsClose }
+    | undefined => {
     const data = JSON.parse(ev.data.toString())
 
     const parseResult = tailSchema.safeParse(data)
@@ -141,7 +221,15 @@ export class TunnelTail extends TunnelClient {
     }
 
     if (parseResult.data.type === 'hello') {
-      return { type: 'hello' }
+      return { type: 'hello', hello: parseResult.data }
+    }
+
+    if (
+      parseResult.data.type === 'ws_open' ||
+      parseResult.data.type === 'ws_frame' ||
+      parseResult.data.type === 'ws_close'
+    ) {
+      return { type: 'ws', message: parseResult.data }
     }
 
     return { type: 'request', request: parseResult.data }
@@ -149,12 +237,18 @@ export class TunnelTail extends TunnelClient {
 }
 
 export class TunnelHead extends TunnelClient {
+  private _capabilities: Set<string> = new Set()
+
   public readonly events: EventEmitter<{
     close: ClientCloseEvent
     error: ClientErrorEvent
     response: TunnelResponse
     open: ClientOpenEvent
-    hello: {}
+    hello: Hello
+    ws_accept: TunnelWsAccept
+    ws_reject: TunnelWsReject
+    ws_frame: TunnelWsFrame
+    ws_close: TunnelWsClose
   }> = this._ev
 
   public constructor(public readonly tunnelId: string, ws: WebSocket) {
@@ -167,11 +261,23 @@ export class TunnelHead extends TunnelClient {
         return
       }
       if (message.type === 'hello') {
-        this.events.emit('hello', {})
+        for (const capability of message.hello.capabilities ?? []) {
+          this._capabilities.add(capability)
+        }
+        this.events.emit('hello', message.hello)
         return
       }
-      this.events.emit('response', message.response)
+      if (message.type === 'response') {
+        this.events.emit('response', message.response)
+        return
+      }
+      this.events.emit(message.message.type, message.message as never)
     })
+  }
+
+  /** True once the tail advertised WebSocket bridging (hello capabilities). */
+  public get supportsWebSockets(): boolean {
+    return this._capabilities.has(WS_CAPABILITY)
   }
 
   public readonly send = (request: Omit<TunnelRequest, 'type'>) => {
@@ -181,9 +287,20 @@ export class TunnelHead extends TunnelClient {
     this._ws.send(JSON.stringify(req))
   }
 
+  /** Ask the tail to open a bridged WebSocket connection; answered by ws_accept / ws_reject. */
+  public readonly openWebSocket = (open: Omit<TunnelWsOpen, 'type'>) => {
+    this._throwIfClosed()
+    const req: TunnelWsOpen = { type: 'ws_open', ...open }
+    this._ws.send(JSON.stringify(req))
+  }
+
   private _parseMessage = (
     ev: WebSocket.MessageEvent
-  ): { type: 'hello' } | { type: 'response'; response: TunnelResponse } | undefined => {
+  ):
+    | { type: 'hello'; hello: Hello }
+    | { type: 'response'; response: TunnelResponse }
+    | { type: 'ws'; message: TunnelWsAccept | TunnelWsReject | TunnelWsFrame | TunnelWsClose }
+    | undefined => {
     const data = JSON.parse(ev.data.toString())
 
     const parseResult = headSchema.safeParse(data)
@@ -192,7 +309,16 @@ export class TunnelHead extends TunnelClient {
     }
 
     if (parseResult.data.type === 'hello') {
-      return { type: 'hello' }
+      return { type: 'hello', hello: parseResult.data }
+    }
+
+    if (
+      parseResult.data.type === 'ws_accept' ||
+      parseResult.data.type === 'ws_reject' ||
+      parseResult.data.type === 'ws_frame' ||
+      parseResult.data.type === 'ws_close'
+    ) {
+      return { type: 'ws', message: parseResult.data }
     }
 
     return { type: 'response', response: parseResult.data }

--- a/tunnel/src/tunnel-server.ts
+++ b/tunnel/src/tunnel-server.ts
@@ -5,6 +5,7 @@ import * as errors from './errors'
 import { EventEmitter } from './event-emitter'
 import * as rooting from './rooting'
 import { TunnelHead } from './tunnel-client'
+import { TunnelHeader } from './types'
 
 export type TunnelServerProps = {
   port?: number
@@ -17,9 +18,23 @@ export type ServerListeningEvent = {}
 export type ServerConnectionEvent = TunnelHead
 export type ServerDisconnectionEvent = { tunnelId: string }
 
+/** How long a visitor socket waits for the tail's ws_accept before giving up. */
+const VISITOR_ACCEPT_TIMEOUT_MS = 10_000
+
+/** Headers a bridged ws_open forwards to the tail (auth cookies, negotiated subprotocols, origin checks). */
+const FORWARDED_VISITOR_HEADERS = ['cookie', 'origin', 'user-agent', 'sec-websocket-protocol', 'x-forwarded-for']
+
+/** ws' close() only accepts 1000 or 3000-4999 — anything else (1001, 1006, …) becomes a normal closure. */
+const sendableCloseCode = (code: number | undefined): number =>
+  code !== undefined && (code === 1000 || (code >= 3000 && code <= 4999)) ? code : 1000
+
+const visitorConnectionId = (): string =>
+  `wsc_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 12)}`
+
 export class TunnelServer {
   private _wss: WebSocket.WebSocketServer
   private _tunnels: Record<string, TunnelHead> = {}
+  private _visitors: Record<string, Map<string, WebSocket>> = {}
   private _closed = false
 
   public readonly events = new EventEmitter<{
@@ -84,14 +99,23 @@ export class TunnelServer {
 
   private _handleConnection = (ws: WebSocket, req: IncomingMessage) => {
     const parseResult = rooting.parseUrl(req.url)
-    if (parseResult.status === 'error') {
-      const code = errors.CLOSE_CODES.INVALID_TUNNEL_ID
-      const { reason } = parseResult
-      ws.close(code, reason)
+    if (parseResult.status === 'success') {
+      this._handleTailConnection(ws, parseResult.tunnelId)
       return
     }
 
-    const { tunnelId } = parseResult
+    // Not a tail registration (`/:tunnelId`): a public visitor upgrading a
+    // WebSocket against a path served by the tail (`/:tunnelId/:path`).
+    const publicResult = rooting.parsePublicUrl(req.url)
+    if (publicResult.status === 'success') {
+      this._handleVisitorConnection(ws, req, publicResult)
+      return
+    }
+
+    ws.close(errors.CLOSE_CODES.INVALID_TUNNEL_ID, parseResult.reason)
+  }
+
+  private _handleTailConnection = (ws: WebSocket, tunnelId: string) => {
     if (this._tunnels[tunnelId]) {
       ws.close(errors.CLOSE_CODES.TUNNEL_ID_CONFLICT, 'tunnel ID already in use')
       return
@@ -104,8 +128,127 @@ export class TunnelServer {
     this._tunnels[tunnelId] = tunnel
   }
 
+  /**
+   * Bridge a visitor's WebSocket to the tail: ws_open asks the tail to dial
+   * its local counterpart, then frames relay in both directions until either
+   * side closes. Frames the visitor sends before the tail accepts are
+   * buffered — the visitor has no way to know the handshake is still in
+   * flight (its upgrade already completed).
+   */
+  private _handleVisitorConnection = (
+    ws: WebSocket,
+    req: IncomingMessage,
+    target: { tunnelId: string; path: string; query?: string }
+  ) => {
+    const tunnel = this._tunnels[target.tunnelId]
+    if (!tunnel) {
+      ws.close(errors.CLOSE_CODES.INVALID_TUNNEL_ID, 'tunnel not found')
+      return
+    }
+    if (!tunnel.supportsWebSockets) {
+      ws.close(errors.CLOSE_CODES.WS_UNSUPPORTED, 'tunnel does not support websocket bridging')
+      return
+    }
+
+    const id = visitorConnectionId()
+    const visitors = (this._visitors[target.tunnelId] ??= new Map())
+    visitors.set(id, ws)
+
+    const headers: Record<string, TunnelHeader> = {}
+    for (const name of FORWARDED_VISITOR_HEADERS) {
+      const value = req.headers[name]
+      if (value !== undefined) headers[name] = value
+    }
+
+    let accepted = false
+    let finished = false
+    const pendingFrames: { data: string; binary: boolean }[] = []
+
+    const acceptTimeout = setTimeout(() => finish(1011, 'tunnel websocket accept timed out'), VISITOR_ACCEPT_TIMEOUT_MS)
+
+    const onAccept = (msg: { id: string }) => {
+      if (msg.id !== id || finished) return
+      accepted = true
+      clearTimeout(acceptTimeout)
+      for (const frame of pendingFrames.splice(0)) {
+        tunnel.sendWebSocketFrame(id, frame.data, frame.binary)
+      }
+    }
+    const onReject = (msg: { id: string; reason?: string }) => {
+      if (msg.id !== id) return
+      finish(1011, msg.reason ?? 'tunnel websocket rejected')
+    }
+    const onFrame = (msg: { id: string; data: string; binary?: boolean }) => {
+      if (msg.id !== id || finished) return
+      ws.send(msg.binary ? Buffer.from(msg.data, 'base64') : msg.data)
+    }
+    const onClose = (msg: { id: string; code?: number; reason?: string }) => {
+      if (msg.id !== id) return
+      finish(msg.code, msg.reason)
+    }
+    const onTunnelClose = () => finish(1001, 'tunnel closed')
+
+    const finish = (code?: number, reason?: string) => {
+      if (finished) return
+      finished = true
+      clearTimeout(acceptTimeout)
+      visitors.delete(id)
+      tunnel.events.off('ws_accept', onAccept)
+      tunnel.events.off('ws_reject', onReject)
+      tunnel.events.off('ws_frame', onFrame)
+      tunnel.events.off('ws_close', onClose)
+      tunnel.events.off('close', onTunnelClose)
+      try {
+        ws.close(sendableCloseCode(code), reason)
+      } catch {
+        // already closing
+      }
+    }
+
+    tunnel.events.on('ws_accept', onAccept)
+    tunnel.events.on('ws_reject', onReject)
+    tunnel.events.on('ws_frame', onFrame)
+    tunnel.events.on('ws_close', onClose)
+    tunnel.events.on('close', onTunnelClose)
+
+    ws.addEventListener('message', (ev: WebSocket.MessageEvent) => {
+      if (finished) return
+      const binary = typeof ev.data !== 'string'
+      const data = binary ? Buffer.from(ev.data as Buffer).toString('base64') : (ev.data as string)
+      if (!accepted) {
+        pendingFrames.push({ data, binary })
+        return
+      }
+      tunnel.sendWebSocketFrame(id, data, binary)
+    })
+    ws.addEventListener('close', (ev: WebSocket.CloseEvent) => {
+      if (finished) return
+      finished = true
+      clearTimeout(acceptTimeout)
+      visitors.delete(id)
+      tunnel.events.off('ws_accept', onAccept)
+      tunnel.events.off('ws_reject', onReject)
+      tunnel.events.off('ws_frame', onFrame)
+      tunnel.events.off('ws_close', onClose)
+      tunnel.events.off('close', onTunnelClose)
+      if (!tunnel.closed) {
+        try {
+          tunnel.closeWebSocket(id, ev.code, ev.reason?.toString())
+        } catch {
+          // tunnel raced shut — nothing to notify
+        }
+      }
+    })
+    ws.addEventListener('error', () => {
+      // close event follows and owns the cleanup
+    })
+
+    tunnel.openWebSocket({ id, path: target.path, ...(target.query !== undefined && { query: target.query }), headers })
+  }
+
   private _handleDisconnection = (tunnelId: string) => {
     delete this._tunnels[tunnelId]
+    delete this._visitors[tunnelId]
     this.events.emit('disconnection', { tunnelId })
   }
 

--- a/tunnel/src/tunnel-server.ts
+++ b/tunnel/src/tunnel-server.ts
@@ -21,12 +21,23 @@ export type ServerDisconnectionEvent = { tunnelId: string }
 /** How long a visitor socket waits for the tail's ws_accept before giving up. */
 const VISITOR_ACCEPT_TIMEOUT_MS = 10_000
 
-/** Headers a bridged ws_open forwards to the tail (auth cookies, negotiated subprotocols, origin checks). */
-const FORWARDED_VISITOR_HEADERS = ['cookie', 'origin', 'user-agent', 'sec-websocket-protocol', 'x-forwarded-for']
+/**
+ * Frames a visitor sends before the tail accepts are buffered (the visitor's
+ * upgrade already completed — it cannot know the handshake is in flight).
+ * The visitor is unauthenticated at this point, so the buffer is hard-capped;
+ * exceeding it closes the socket instead of holding attacker-controlled bytes.
+ */
+const MAX_PENDING_FRAMES = 64
+const MAX_PENDING_BYTES = 256 * 1024
 
-/** ws' close() only accepts 1000 or 3000-4999 — anything else (1001, 1006, …) becomes a normal closure. */
+/** Headers a bridged ws_open forwards to the tail (auth cookies, origin checks). */
+const FORWARDED_VISITOR_HEADERS = ['cookie', 'origin', 'user-agent', 'x-forwarded-for']
+
+/** Only codes an endpoint may SEND (RFC 6455): reserved ones (1005, 1006, …) become a normal closure. */
 const sendableCloseCode = (code: number | undefined): number =>
-  code !== undefined && (code === 1000 || (code >= 3000 && code <= 4999)) ? code : 1000
+  code !== undefined && ((code >= 1000 && code <= 1003) || (code >= 1007 && code <= 1011) || (code >= 3000 && code <= 4999))
+    ? code
+    : 1000
 
 const visitorConnectionId = (): string =>
   `wsc_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 12)}`
@@ -162,9 +173,39 @@ export class TunnelServer {
 
     let accepted = false
     let finished = false
+    let pendingBytes = 0
     const pendingFrames: { data: string; binary: boolean }[] = []
 
-    const acceptTimeout = setTimeout(() => finish(1011, 'tunnel websocket accept timed out'), VISITOR_ACCEPT_TIMEOUT_MS)
+    const teardown = (opts: { visitorCode?: number; visitorReason?: string; notifyTail: boolean }) => {
+      if (finished) return
+      finished = true
+      clearTimeout(acceptTimeout)
+      pendingFrames.length = 0
+      visitors.delete(id)
+      tunnel.events.off('ws_accept', onAccept)
+      tunnel.events.off('ws_reject', onReject)
+      tunnel.events.off('ws_frame', onFrame)
+      tunnel.events.off('ws_close', onClose)
+      tunnel.events.off('close', onTunnelClose)
+      if (opts.notifyTail && !tunnel.closed) {
+        try {
+          tunnel.closeWebSocket(id, opts.visitorCode, opts.visitorReason)
+        } catch {
+          // tunnel raced shut — nothing to notify
+        }
+      }
+      try {
+        ws.close(sendableCloseCode(opts.visitorCode), opts.visitorReason)
+      } catch {
+        // already closing
+      }
+    }
+
+    const acceptTimeout = setTimeout(
+      // Notify the tail: a late accept would otherwise stream into the void.
+      () => teardown({ visitorCode: 1011, visitorReason: 'tunnel websocket accept timed out', notifyTail: true }),
+      VISITOR_ACCEPT_TIMEOUT_MS
+    )
 
     const onAccept = (msg: { id: string }) => {
       if (msg.id !== id || finished) return
@@ -173,10 +214,11 @@ export class TunnelServer {
       for (const frame of pendingFrames.splice(0)) {
         tunnel.sendWebSocketFrame(id, frame.data, frame.binary)
       }
+      pendingBytes = 0
     }
     const onReject = (msg: { id: string; reason?: string }) => {
       if (msg.id !== id) return
-      finish(1011, msg.reason ?? 'tunnel websocket rejected')
+      teardown({ visitorCode: 1011, visitorReason: msg.reason ?? 'tunnel websocket rejected', notifyTail: false })
     }
     const onFrame = (msg: { id: string; data: string; binary?: boolean }) => {
       if (msg.id !== id || finished) return
@@ -184,26 +226,9 @@ export class TunnelServer {
     }
     const onClose = (msg: { id: string; code?: number; reason?: string }) => {
       if (msg.id !== id) return
-      finish(msg.code, msg.reason)
+      teardown({ visitorCode: msg.code, visitorReason: msg.reason, notifyTail: false })
     }
-    const onTunnelClose = () => finish(1001, 'tunnel closed')
-
-    const finish = (code?: number, reason?: string) => {
-      if (finished) return
-      finished = true
-      clearTimeout(acceptTimeout)
-      visitors.delete(id)
-      tunnel.events.off('ws_accept', onAccept)
-      tunnel.events.off('ws_reject', onReject)
-      tunnel.events.off('ws_frame', onFrame)
-      tunnel.events.off('ws_close', onClose)
-      tunnel.events.off('close', onTunnelClose)
-      try {
-        ws.close(sendableCloseCode(code), reason)
-      } catch {
-        // already closing
-      }
-    }
+    const onTunnelClose = () => teardown({ visitorCode: 1001, visitorReason: 'tunnel closed', notifyTail: false })
 
     tunnel.events.on('ws_accept', onAccept)
     tunnel.events.on('ws_reject', onReject)
@@ -216,6 +241,12 @@ export class TunnelServer {
       const binary = typeof ev.data !== 'string'
       const data = binary ? Buffer.from(ev.data as Buffer).toString('base64') : (ev.data as string)
       if (!accepted) {
+        // Unauthenticated bytes: hard-capped, never held indefinitely.
+        if (pendingFrames.length >= MAX_PENDING_FRAMES || pendingBytes + data.length > MAX_PENDING_BYTES) {
+          teardown({ visitorCode: 1009, visitorReason: 'too much data before tunnel accept', notifyTail: true })
+          return
+        }
+        pendingBytes += data.length
         pendingFrames.push({ data, binary })
         return
       }
@@ -225,6 +256,7 @@ export class TunnelServer {
       if (finished) return
       finished = true
       clearTimeout(acceptTimeout)
+      pendingFrames.length = 0
       visitors.delete(id)
       tunnel.events.off('ws_accept', onAccept)
       tunnel.events.off('ws_reject', onReject)

--- a/tunnel/src/types.ts
+++ b/tunnel/src/types.ts
@@ -49,11 +49,13 @@ export const tunnelWsOpenSchema = z.object({
   headers: z.record(tunnelHeaderSchema).optional()
 })
 
+// No subprotocol on ws_accept: the visitor's upgrade completes (without one)
+// before the tail answers, so a tail-selected subprotocol could never be
+// honored — offering the field would only discard it silently.
 export type TunnelWsAccept = z.infer<typeof tunnelWsAcceptSchema>
 export const tunnelWsAcceptSchema = z.object({
   type: z.literal('ws_accept'),
-  id: z.string(),
-  subprotocol: z.string().optional()
+  id: z.string()
 })
 
 export type TunnelWsReject = z.infer<typeof tunnelWsRejectSchema>

--- a/tunnel/src/types.ts
+++ b/tunnel/src/types.ts
@@ -23,9 +23,75 @@ export const tunnelResponseSchema = z.object({
   body: z.string().optional()
 })
 
-// dummy data to keep the connection alive
+// dummy data to keep the connection alive; `capabilities` advertises optional
+// protocol extensions (a head only sends ws_* frames to a tail that said 'ws',
+// so a pre-websocket tail never receives frames it cannot parse)
 export type Hello = z.infer<typeof helloSchema>
-export const helloSchema = z.object({ type: z.literal('hello') })
+export const helloSchema = z.object({
+  type: z.literal('hello'),
+  capabilities: z.string().array().optional()
+})
 
-export const tailSchema = z.union([tunnelRequestSchema, helloSchema])
-export const headSchema = z.union([tunnelResponseSchema, helloSchema])
+export const WS_CAPABILITY = 'ws'
+
+/**
+ * WebSocket bridging: a public visitor's socket terminated at the tunnel
+ * server is multiplexed over the tunnel connection frame-by-frame, keyed by a
+ * per-socket `id`. head → tail: ws_open / ws_frame / ws_close.
+ * tail → head: ws_accept | ws_reject (answer to ws_open) / ws_frame / ws_close.
+ */
+export type TunnelWsOpen = z.infer<typeof tunnelWsOpenSchema>
+export const tunnelWsOpenSchema = z.object({
+  type: z.literal('ws_open'),
+  id: z.string(),
+  path: z.string(),
+  query: z.string().optional(),
+  headers: z.record(tunnelHeaderSchema).optional()
+})
+
+export type TunnelWsAccept = z.infer<typeof tunnelWsAcceptSchema>
+export const tunnelWsAcceptSchema = z.object({
+  type: z.literal('ws_accept'),
+  id: z.string(),
+  subprotocol: z.string().optional()
+})
+
+export type TunnelWsReject = z.infer<typeof tunnelWsRejectSchema>
+export const tunnelWsRejectSchema = z.object({
+  type: z.literal('ws_reject'),
+  id: z.string(),
+  reason: z.string().optional()
+})
+
+export type TunnelWsFrame = z.infer<typeof tunnelWsFrameSchema>
+export const tunnelWsFrameSchema = z.object({
+  type: z.literal('ws_frame'),
+  id: z.string(),
+  /** utf-8 text, or base64 when `binary` is true */
+  data: z.string(),
+  binary: z.boolean().optional()
+})
+
+export type TunnelWsClose = z.infer<typeof tunnelWsCloseSchema>
+export const tunnelWsCloseSchema = z.object({
+  type: z.literal('ws_close'),
+  id: z.string(),
+  code: z.number().optional(),
+  reason: z.string().optional()
+})
+
+export const tailSchema = z.union([
+  tunnelRequestSchema,
+  helloSchema,
+  tunnelWsOpenSchema,
+  tunnelWsFrameSchema,
+  tunnelWsCloseSchema
+])
+export const headSchema = z.union([
+  tunnelResponseSchema,
+  helloSchema,
+  tunnelWsAcceptSchema,
+  tunnelWsRejectSchema,
+  tunnelWsFrameSchema,
+  tunnelWsCloseSchema
+])


### PR DESCRIPTION
## Summary

The tunnel protocol was strictly request/response, so a visitor upgrading a WebSocket against a tunneled path (e.g. the VDK edge webchat behind `tunnel.botpress.cloud/<tunnelId>/edge`) got its `101` from the server's WSS and then hung forever — there was no way to relay frames to the tail. This adds WebSocket bridging, multiplexed over the tunnel's existing connection.

- **Protocol** (`types.ts`): new frames keyed by a per-socket connection id — `ws_open` / `ws_accept` / `ws_reject` for the handshake, `ws_frame` (utf-8 text, base64 when `binary`) and `ws_close` for the lifetime. Existing request/response/hello schemas untouched.
- **Capability negotiation**: tails advertise `capabilities: ['ws']` in `hello` (now sent automatically on open). The head only bridges to tails that advertised it, and refuses other visitors with a new close code `4006 WS_UNSUPPORTED` — a pre-websocket tail never receives frames it can't parse (which would make it close the whole tunnel), and old servers strip the unknown `hello` field harmlessly.
- **Server** (`tunnel-server.ts`): upgrades on `/:tunnelId/:path` — previously closed as invalid tail registrations — now bridge to the tail: 10s accept timeout, frames the visitor sends before the tail accepts are buffered, closes propagate in both directions, and all visitor sockets close when their tunnel disconnects.
- **Client** (`tunnel-client.ts`): `TunnelTail.acceptWebSocket/rejectWebSocket` + shared `sendWebSocketFrame/closeWebSocket`; `TunnelHead.openWebSocket` + `supportsWebSockets`. Also upstreams the patch VDK carried against the published dist: under Bun the bundled `ws` client rejects the `101`, so the tail prefers Bun's native WebSocket there.

Once this publishes and the tunnel service redeploys with it, no service-side code changes should be needed if its WSS is a `TunnelServer` attached to its HTTP server — the bridging is entirely in the library. Consumer-side, `vdk dev` gains a `ws_open → local workerd socket` relay (separate PR in the vdk repo).

## Test plan

- `pnpm exec tsc --noEmit` clean.
- New e2e: `websocket-bridge` (visitor → server → tail echo, path/query fidelity, pre-accept buffering, close propagation to the tail) and `websocket-unsupported` (clean `4006` refusal when the tail didn't advertise the capability). Existing `nodejs-success` / `nodejs-invalid-request` still pass.
- Verified live against a real workerd edge socket: simulated browser → local `TunnelServer` → `TunnelTail` (wired like vdk's dev-runtime) → VDK runtime worker's conversation WebSocket returned the edge protocol's `ready` frame through the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)